### PR TITLE
Feat/v3

### DIFF
--- a/app/Enums/ProposalTrackingItemResult.php
+++ b/app/Enums/ProposalTrackingItemResult.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum ProposalTrackingItemResult: string
+{
+    case Pending = 'pending';
+    case Won = 'won';
+    case Lost = 'lost';
+}

--- a/app/Enums/ProposalTrackingStatus.php
+++ b/app/Enums/ProposalTrackingStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum ProposalTrackingStatus: string
+{
+    case Open = 'open';
+    case Finished = 'finished';
+}

--- a/app/Http/Controllers/ProposalCatalogController.php
+++ b/app/Http/Controllers/ProposalCatalogController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Proposal\ProposalCatalogService;
+use Illuminate\Http\Request;
+
+class ProposalCatalogController extends Controller
+{
+    public function __construct(private ProposalCatalogService $proposalCatalogService) {}
+
+    public function get($proposalId)
+    {
+        return $this->response($this->proposalCatalogService->get($proposalId));
+    }
+
+    public function update(Request $request, $proposalId)
+    {
+        $result = $this->proposalCatalogService->update($request, $proposalId);
+
+        if ($result['status']) {
+            $result['message'] = 'Catálogo atualizado com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function uploadImage(Request $request, $proposalId, $itemId)
+    {
+        $result = $this->proposalCatalogService->uploadImage($request, $proposalId, $itemId);
+
+        if ($result['status']) {
+            $result['message'] = 'Imagem atualizada com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function deleteImage($proposalId, $itemId)
+    {
+        $result = $this->proposalCatalogService->deleteImage($proposalId, $itemId);
+
+        if ($result['status']) {
+            $result['message'] = 'Imagem removida com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function generate($proposalId)
+    {
+        $result = $this->proposalCatalogService->generate($proposalId);
+
+        if ($result['status']) {
+            $result['message'] = 'Catálogo gerado com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function view($catalogId)
+    {
+        return $this->response($this->proposalCatalogService->view($catalogId));
+    }
+
+    private function response(array $result)
+    {
+        return response()->json([
+            'status' => $result['status'],
+            'message' => $result['message'] ?? null,
+            'data' => $result['data'] ?? null,
+            'error' => $result['error'] ?? null,
+        ], $result['statusCode'] ?? 200);
+    }
+}

--- a/app/Http/Controllers/ProposalTrackingController.php
+++ b/app/Http/Controllers/ProposalTrackingController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Proposal\ProposalTrackingService;
+use Illuminate\Http\Request;
+
+class ProposalTrackingController extends Controller
+{
+    public function __construct(private ProposalTrackingService $proposalTrackingService) {}
+
+    public function get($proposalId)
+    {
+        return $this->response($this->proposalTrackingService->get($proposalId));
+    }
+
+    public function update(Request $request, $proposalId)
+    {
+        $result = $this->proposalTrackingService->update($request, $proposalId);
+
+        if ($result['status']) {
+            $result['message'] = 'Acompanhamento atualizado com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function applyDiscount(Request $request, $proposalId)
+    {
+        $result = $this->proposalTrackingService->applyDiscount($request, $proposalId);
+
+        if ($result['status']) {
+            $result['message'] = 'Desconto aplicado com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function finish($proposalId)
+    {
+        $result = $this->proposalTrackingService->finish($proposalId);
+
+        if ($result['status']) {
+            $result['message'] = 'Acompanhamento finalizado com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function reopen($proposalId)
+    {
+        $result = $this->proposalTrackingService->reopen($proposalId);
+
+        if ($result['status']) {
+            $result['message'] = 'Acompanhamento reaberto com sucesso';
+        }
+
+        return $this->response($result);
+    }
+
+    public function print($proposalId)
+    {
+        return $this->response($this->proposalTrackingService->printData($proposalId));
+    }
+
+    public function export($proposalId)
+    {
+        $result = $this->proposalTrackingService->export($proposalId);
+
+        if (! $result['status']) {
+            return $this->response($result);
+        }
+
+        return response($result['data']['content'], 200, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="'.$result['data']['filename'].'"',
+        ]);
+    }
+
+    private function response(array $result)
+    {
+        return response()->json([
+            'status' => $result['status'],
+            'message' => $result['message'] ?? null,
+            'data' => $result['data'] ?? null,
+            'error' => $result['error'] ?? null,
+        ], $result['statusCode'] ?? 200);
+    }
+}

--- a/app/Models/CalendarTender.php
+++ b/app/Models/CalendarTender.php
@@ -20,10 +20,12 @@ class CalendarTender extends Model
         'tender_id',
         'user_id',
         'status',
+        'calendar_date',
     ];
 
     protected $casts = [
         'status' => CalendarTenderStatus::class,
+        'calendar_date' => 'datetime',
     ];
 
     public function tender()

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -10,6 +10,7 @@ class Company extends Model
     use HasFactory;
 
     const CREATED_AT = 'created_at';
+
     const UPDATED_AT = 'updated_at';
 
     public $table = 'companies';
@@ -47,7 +48,7 @@ class Company extends Model
             return $this->attributes['logo'];
         }
 
-        return url('storage/' . $this->attributes['logo']);
+        return url('storage/'.$this->attributes['logo']);
     }
 
     public function user()
@@ -58,5 +59,10 @@ class Company extends Model
     public function proposals()
     {
         return $this->hasMany(Proposal::class);
+    }
+
+    public function proposalCatalogs()
+    {
+        return $this->hasMany(ProposalCatalog::class);
     }
 }

--- a/app/Models/Proposal.php
+++ b/app/Models/Proposal.php
@@ -63,4 +63,14 @@ class Proposal extends Model
     {
         return $this->hasMany(ProposalItem::class);
     }
+
+    public function tracking()
+    {
+        return $this->hasOne(ProposalTracking::class);
+    }
+
+    public function catalog()
+    {
+        return $this->hasOne(ProposalCatalog::class);
+    }
 }

--- a/app/Models/ProposalCatalog.php
+++ b/app/Models/ProposalCatalog.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ProposalCatalog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'proposal_id',
+        'user_id',
+        'company_id',
+        'title',
+        'subtitle',
+        'general_notes',
+        'organ_name',
+        'organ_state',
+        'purchase_number',
+        'process_number',
+        'receipt_date',
+        'opening_date',
+        'company_snapshot',
+        'last_updated_by',
+        'generated_at',
+    ];
+
+    protected $casts = [
+        'receipt_date' => 'date',
+        'opening_date' => 'date',
+        'company_snapshot' => 'array',
+        'generated_at' => 'datetime',
+    ];
+
+    public function proposal()
+    {
+        return $this->belongsTo(Proposal::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function company()
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function items()
+    {
+        return $this->hasMany(ProposalCatalogItem::class)->orderBy('position');
+    }
+}

--- a/app/Models/ProposalCatalogItem.php
+++ b/app/Models/ProposalCatalogItem.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+
+class ProposalCatalogItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'proposal_catalog_id',
+        'proposal_item_id',
+        'title',
+        'specification',
+        'quantity',
+        'unit',
+        'brand',
+        'position',
+        'image_path',
+        'image_original_name',
+        'image_mime',
+    ];
+
+    protected $casts = [
+        'quantity' => 'decimal:4',
+        'position' => 'integer',
+    ];
+
+    protected $hidden = [
+        'image_path',
+    ];
+
+    protected $appends = [
+        'image_url',
+    ];
+
+    public function catalog()
+    {
+        return $this->belongsTo(ProposalCatalog::class, 'proposal_catalog_id');
+    }
+
+    public function proposalItem()
+    {
+        return $this->belongsTo(ProposalItem::class);
+    }
+
+    public function getImageUrlAttribute(): ?string
+    {
+        return $this->image_path
+            ? Storage::disk('public')->url($this->image_path)
+            : null;
+    }
+}

--- a/app/Models/ProposalItem.php
+++ b/app/Models/ProposalItem.php
@@ -32,4 +32,14 @@ class ProposalItem extends Model
     {
         return $this->belongsTo(Proposal::class);
     }
+
+    public function trackingItem()
+    {
+        return $this->hasOne(ProposalTrackingItem::class);
+    }
+
+    public function catalogItem()
+    {
+        return $this->hasOne(ProposalCatalogItem::class);
+    }
 }

--- a/app/Models/ProposalTracking.php
+++ b/app/Models/ProposalTracking.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ProposalTrackingStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ProposalTracking extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'proposal_id',
+        'discount_percentage',
+        'status',
+        'last_updated_by',
+        'finished_at',
+    ];
+
+    protected $casts = [
+        'discount_percentage' => 'decimal:4',
+        'status' => ProposalTrackingStatus::class,
+        'finished_at' => 'datetime',
+    ];
+
+    public function proposal()
+    {
+        return $this->belongsTo(Proposal::class);
+    }
+
+    public function items()
+    {
+        return $this->hasMany(ProposalTrackingItem::class);
+    }
+
+    public function lastUpdatedBy()
+    {
+        return $this->belongsTo(User::class, 'last_updated_by');
+    }
+}

--- a/app/Models/ProposalTrackingItem.php
+++ b/app/Models/ProposalTrackingItem.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ProposalTrackingItemResult;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ProposalTrackingItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'proposal_tracking_id',
+        'proposal_item_id',
+        'result',
+        'minimum_unit_price',
+        'classified_at',
+        'classified_by',
+    ];
+
+    protected $casts = [
+        'result' => ProposalTrackingItemResult::class,
+        'minimum_unit_price' => 'decimal:4',
+        'classified_at' => 'datetime',
+    ];
+
+    public function tracking()
+    {
+        return $this->belongsTo(ProposalTracking::class, 'proposal_tracking_id');
+    }
+
+    public function proposalItem()
+    {
+        return $this->belongsTo(ProposalItem::class);
+    }
+
+    public function classifiedBy()
+    {
+        return $this->belongsTo(User::class, 'classified_by');
+    }
+
+    public function rankings()
+    {
+        return $this->hasMany(ProposalTrackingItemRanking::class);
+    }
+}

--- a/app/Models/ProposalTrackingItemRanking.php
+++ b/app/Models/ProposalTrackingItemRanking.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ProposalTrackingItemRanking extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'proposal_tracking_item_id',
+        'position',
+        'company',
+        'brand',
+        'price',
+    ];
+
+    protected $casts = [
+        'position' => 'integer',
+        'price' => 'decimal:4',
+    ];
+
+    public function trackingItem()
+    {
+        return $this->belongsTo(ProposalTrackingItem::class, 'proposal_tracking_item_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ class User extends Authenticatable implements JWTSubject
     use HasApiTokens, HasFactory, Notifiable, SoftDeletes;
 
     const CREATED_AT = 'created_at';
+
     const UPDATED_AT = 'updated_at';
 
     /**
@@ -68,16 +69,19 @@ class User extends Authenticatable implements JWTSubject
         return [];
     }
 
-    public function favorites(){
+    public function favorites()
+    {
         return $this->hasMany(FavoriteTender::class);
     }
 
-    public function calendarTenders(){
+    public function calendarTenders()
+    {
         return $this->hasMany(CalendarTender::class);
     }
 
-    public function files()  {
-        return $this->hasMany(File::class);        
+    public function files()
+    {
+        return $this->hasMany(File::class);
     }
 
     public function company()
@@ -88,5 +92,10 @@ class User extends Authenticatable implements JWTSubject
     public function proposals()
     {
         return $this->hasMany(Proposal::class);
+    }
+
+    public function proposalCatalogs()
+    {
+        return $this->hasMany(ProposalCatalog::class);
     }
 }

--- a/app/Services/Proposal/ProposalCatalogService.php
+++ b/app/Services/Proposal/ProposalCatalogService.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace App\Services\Proposal;
+
+use App\Models\Company;
+use App\Models\Proposal;
+use App\Models\ProposalCatalog;
+use Exception;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+
+class ProposalCatalogService
+{
+    public function get(int $proposalId): array
+    {
+        try {
+            $proposal = $this->findUserProposal($proposalId);
+            $catalog = $this->ensureCatalog($proposal);
+
+            return ['status' => true, 'data' => $this->payload($catalog)];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta não encontrada.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function update(Request $request, int $proposalId): array
+    {
+        try {
+            $validator = Validator::make($request->all(), [
+                'title' => ['sometimes', 'required', 'string', 'max:255'],
+                'subtitle' => ['sometimes', 'nullable', 'string', 'max:255'],
+                'general_notes' => ['sometimes', 'nullable', 'string'],
+                'organ_name' => ['sometimes', 'nullable', 'string', 'max:255'],
+                'organ_state' => ['sometimes', 'nullable', 'string', 'max:255'],
+                'purchase_number' => ['sometimes', 'nullable', 'string', 'max:255'],
+                'process_number' => ['sometimes', 'nullable', 'string', 'max:255'],
+                'receipt_date' => ['sometimes', 'nullable', 'date'],
+                'opening_date' => ['sometimes', 'nullable', 'date'],
+                'items' => ['sometimes', 'array'],
+                'items.*.id' => ['nullable', 'integer', 'distinct', 'exists:proposal_catalog_items,id'],
+                'items.*.proposal_item_id' => ['nullable', 'integer', 'distinct', 'exists:proposal_items,id'],
+                'items.*.title' => ['nullable', 'string', 'max:255'],
+                'items.*.specification' => ['nullable', 'string'],
+                'items.*.quantity' => ['nullable', 'numeric', 'min:0'],
+                'items.*.unit' => ['nullable', 'string', 'max:255'],
+                'items.*.brand' => ['nullable', 'string', 'max:255'],
+                'items.*.position' => ['nullable', 'integer', 'min:1', 'distinct'],
+            ]);
+
+            if ($validator->fails()) {
+                return ['status' => false, 'error' => $validator->errors(), 'statusCode' => 400];
+            }
+
+            $proposal = $this->findUserProposal($proposalId);
+            $catalog = $this->ensureCatalog($proposal);
+            $data = $validator->validated();
+            $submittedItems = collect($data['items'] ?? []);
+
+            if (array_key_exists('items', $data)) {
+                $catalogItems = $catalog->items()->get()->keyBy('id');
+                $catalogItemIds = $catalogItems->keys();
+                $proposalItemIds = $proposal->items()->pluck('id');
+
+                if ($submittedItems->pluck('id')->filter()->contains(fn ($id) => ! $catalogItemIds->contains($id))) {
+                    return [
+                        'status' => false,
+                        'error' => 'Um ou mais itens não pertencem ao catálogo informado.',
+                        'statusCode' => 400,
+                    ];
+                }
+
+                if ($submittedItems->pluck('proposal_item_id')->filter()->contains(fn ($id) => ! $proposalItemIds->contains($id))) {
+                    return [
+                        'status' => false,
+                        'error' => 'Um ou mais itens de origem não pertencem à proposta informada.',
+                        'statusCode' => 400,
+                    ];
+                }
+
+                foreach ($submittedItems->whereNotNull('id') as $submittedItem) {
+                    $catalogItem = $catalogItems->get($submittedItem['id']);
+
+                    if (
+                        array_key_exists('proposal_item_id', $submittedItem)
+                        && $submittedItem['proposal_item_id'] !== $catalogItem->proposal_item_id
+                    ) {
+                        return [
+                            'status' => false,
+                            'error' => 'O item de origem de um item existente não pode ser alterado.',
+                            'statusCode' => 400,
+                        ];
+                    }
+                }
+            }
+
+            $imagesToDelete = [];
+
+            DB::transaction(function () use ($catalog, $data, $submittedItems, &$imagesToDelete): void {
+                $catalog->update(array_merge(
+                    $this->catalogAttributes($data),
+                    [
+                        'last_updated_by' => Auth::id(),
+                        'generated_at' => null,
+                    ]
+                ));
+
+                if (! array_key_exists('items', $data)) {
+                    return;
+                }
+
+                $existingItems = $catalog->items()->get()->keyBy('id');
+
+                // Libera temporariamente as posições para permitir trocas sem
+                // violar a restrição única durante a mesma transação.
+                $catalog->items()->update(['position' => DB::raw('position + 1000000')]);
+
+                $orderedItems = $submittedItems
+                    ->values()
+                    ->sortBy(fn (array $item, int $index) => $item['position'] ?? (1000000 + $index))
+                    ->values();
+                $keptIds = [];
+
+                foreach ($orderedItems as $index => $itemData) {
+                    $attributes = [
+                        'title' => $itemData['title'] ?? null,
+                        'specification' => $itemData['specification'] ?? null,
+                        'quantity' => $itemData['quantity'] ?? null,
+                        'unit' => $itemData['unit'] ?? null,
+                        'brand' => $itemData['brand'] ?? null,
+                        'position' => $index + 1,
+                    ];
+
+                    if (! empty($itemData['id'])) {
+                        $item = $existingItems->get($itemData['id'])->refresh();
+                        $attributes['proposal_item_id'] = $item->proposal_item_id;
+                        $item->update($attributes);
+                    } else {
+                        $attributes['proposal_item_id'] = $itemData['proposal_item_id'] ?? null;
+                        $item = $catalog->items()->create($attributes);
+                    }
+
+                    $keptIds[] = $item->id;
+                }
+
+                $removedItems = $catalog->items()->whereNotIn('id', $keptIds)->get();
+                $imagesToDelete = $removedItems->pluck('image_path')->filter()->all();
+                $catalog->items()->whereNotIn('id', $keptIds)->delete();
+            });
+
+            foreach ($imagesToDelete as $imagePath) {
+                Storage::disk('public')->delete($imagePath);
+            }
+
+            return ['status' => true, 'data' => $this->payload($catalog->fresh())];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta não encontrada.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function uploadImage(Request $request, int $proposalId, int $itemId): array
+    {
+        try {
+            $validator = Validator::make($request->all(), [
+                'image' => ['required', 'image', 'mimes:jpg,jpeg,png,webp', 'max:5120'],
+            ]);
+
+            if ($validator->fails()) {
+                return ['status' => false, 'error' => $validator->errors(), 'statusCode' => 400];
+            }
+
+            $proposal = $this->findUserProposal($proposalId);
+            $catalog = $this->ensureCatalog($proposal);
+            $item = $catalog->items()->findOrFail($itemId);
+            $image = $request->file('image');
+            $oldPath = $item->image_path;
+            $path = $image->store("proposal-catalogs/{$catalog->id}", 'public');
+
+            try {
+                $item->update([
+                    'image_path' => $path,
+                    'image_original_name' => $image->getClientOriginalName(),
+                    'image_mime' => $image->getMimeType(),
+                ]);
+                $catalog->update([
+                    'last_updated_by' => Auth::id(),
+                    'generated_at' => null,
+                ]);
+            } catch (Exception $error) {
+                Storage::disk('public')->delete($path);
+                throw $error;
+            }
+
+            if ($oldPath) {
+                Storage::disk('public')->delete($oldPath);
+            }
+
+            return ['status' => true, 'data' => $item->fresh()];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta, catálogo ou item não encontrado.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function deleteImage(int $proposalId, int $itemId): array
+    {
+        try {
+            $proposal = $this->findUserProposal($proposalId);
+            $catalog = $this->ensureCatalog($proposal);
+            $item = $catalog->items()->findOrFail($itemId);
+            $oldPath = $item->image_path;
+
+            $item->update([
+                'image_path' => null,
+                'image_original_name' => null,
+                'image_mime' => null,
+            ]);
+            $catalog->update([
+                'last_updated_by' => Auth::id(),
+                'generated_at' => null,
+            ]);
+
+            if ($oldPath) {
+                Storage::disk('public')->delete($oldPath);
+            }
+
+            return ['status' => true, 'data' => $item->fresh()];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta, catálogo ou item não encontrado.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function generate(int $proposalId): array
+    {
+        try {
+            $proposal = $this->findUserProposal($proposalId);
+            $catalog = $this->ensureCatalog($proposal);
+            $catalog->update([
+                'generated_at' => now(),
+                'last_updated_by' => Auth::id(),
+            ]);
+
+            return ['status' => true, 'data' => $this->payload($catalog->fresh())];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta não encontrada.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function view(int $catalogId): array
+    {
+        try {
+            $catalog = ProposalCatalog::where('user_id', Auth::id())->findOrFail($catalogId);
+
+            return ['status' => true, 'data' => $this->payload($catalog)];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Catálogo não encontrado.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    private function findUserProposal(int $proposalId): Proposal
+    {
+        return Proposal::where('user_id', Auth::id())->findOrFail($proposalId);
+    }
+
+    private function ensureCatalog(Proposal $proposal): ProposalCatalog
+    {
+        return DB::transaction(function () use ($proposal): ProposalCatalog {
+            $proposal = Proposal::whereKey($proposal->id)->lockForUpdate()->firstOrFail();
+            $existing = $proposal->catalog()->first();
+
+            if ($existing) {
+                return $existing;
+            }
+
+            $company = $proposal->company;
+            $catalog = $proposal->catalog()->create([
+                'user_id' => $proposal->user_id,
+                'company_id' => $proposal->company_id,
+                'title' => 'Catálogo de Produtos',
+                'organ_name' => $proposal->organ_name,
+                'organ_state' => $proposal->organ_state,
+                'purchase_number' => $proposal->purchase_number,
+                'process_number' => $proposal->process_number,
+                'receipt_date' => $proposal->receipt_date,
+                'opening_date' => $proposal->opening_date,
+                'company_snapshot' => $company
+                    ? $this->companySnapshot($company)
+                    : $proposal->company_snapshot,
+                'last_updated_by' => Auth::id(),
+            ]);
+
+            $items = $proposal->items()->orderBy('id')->get()->values()->map(
+                fn ($item, int $index) => [
+                    'proposal_item_id' => $item->id,
+                    'title' => $item->specification,
+                    'specification' => $item->specification,
+                    'quantity' => $item->quantity,
+                    'unit' => $item->unit,
+                    'brand' => $item->brand,
+                    'position' => $index + 1,
+                ]
+            )->all();
+
+            $catalog->items()->createMany($items);
+
+            return $catalog;
+        });
+    }
+
+    private function payload(ProposalCatalog $catalog): ProposalCatalog
+    {
+        return $catalog->load(['items', 'proposal:id,title,status', 'company:id,corporate_reason,fantasy_name']);
+    }
+
+    private function catalogAttributes(array $data): array
+    {
+        return collect($data)->only([
+            'title',
+            'subtitle',
+            'general_notes',
+            'organ_name',
+            'organ_state',
+            'purchase_number',
+            'process_number',
+            'receipt_date',
+            'opening_date',
+        ])->all();
+    }
+
+    private function companySnapshot(Company $company): array
+    {
+        return $company->only([
+            'id',
+            'cnpj',
+            'corporate_reason',
+            'fantasy_name',
+            'street',
+            'number',
+            'complement',
+            'neighborhood',
+            'city',
+            'state',
+            'zipcode',
+            'phone',
+            'email',
+            'logo',
+        ]);
+    }
+}

--- a/app/Services/Proposal/ProposalTrackingService.php
+++ b/app/Services/Proposal/ProposalTrackingService.php
@@ -1,0 +1,519 @@
+<?php
+
+namespace App\Services\Proposal;
+
+use App\Enums\ProposalTrackingItemResult;
+use App\Enums\ProposalTrackingStatus;
+use App\Models\Proposal;
+use App\Models\ProposalItem;
+use App\Models\ProposalTracking;
+use App\Models\ProposalTrackingItem;
+use Exception;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Enum;
+
+class ProposalTrackingService
+{
+    public function get(int $proposalId): array
+    {
+        try {
+            $proposal = $this->findUserProposal($proposalId);
+            $tracking = $this->ensureTracking($proposal);
+
+            return ['status' => true, 'data' => $this->payload($proposal, $tracking)];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta não encontrada.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function update($request, int $proposalId): array
+    {
+        try {
+            $validator = Validator::make($request->all(), [
+                'discount_percentage' => ['sometimes', 'nullable', 'numeric', 'min:0', 'max:100'],
+                'items' => ['sometimes', 'array'],
+                'items.*.proposal_item_id' => ['required', 'integer', 'distinct', 'exists:proposal_items,id'],
+                'items.*.result' => ['sometimes', new Enum(ProposalTrackingItemResult::class)],
+                'items.*.minimum_unit_price' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+                'items.*.rankings' => ['sometimes', 'array', 'max:3'],
+                'items.*.rankings.*.position' => ['required', 'integer', 'between:1,3'],
+                'items.*.rankings.*.company' => ['required', 'string', 'max:255'],
+                'items.*.rankings.*.brand' => ['nullable', 'string', 'max:255'],
+                'items.*.rankings.*.price' => ['required', 'numeric', 'min:0'],
+            ]);
+
+            if ($validator->fails()) {
+                return ['status' => false, 'error' => $validator->errors(), 'statusCode' => 400];
+            }
+
+            $proposal = $this->findUserProposal($proposalId);
+            $tracking = $this->ensureTracking($proposal);
+
+            if ($tracking->status === ProposalTrackingStatus::Finished) {
+                return [
+                    'status' => false,
+                    'error' => 'O acompanhamento está finalizado. Reabra-o antes de editar.',
+                    'statusCode' => 409,
+                ];
+            }
+
+            $data = $validator->validated();
+            $submittedItems = collect($data['items'] ?? []);
+            $proposalItemIds = $proposal->items()->pluck('id');
+
+            if ($submittedItems->contains(fn ($item) => ! $proposalItemIds->contains($item['proposal_item_id']))) {
+                return [
+                    'status' => false,
+                    'error' => 'Um ou mais itens não pertencem à proposta informada.',
+                    'statusCode' => 400,
+                ];
+            }
+
+            $trackingItems = $tracking->items()
+                ->with('rankings')
+                ->whereIn('proposal_item_id', $submittedItems->pluck('proposal_item_id'))
+                ->get()
+                ->keyBy('proposal_item_id');
+
+            foreach ($submittedItems as $submittedItem) {
+                $trackingItem = $trackingItems->get($submittedItem['proposal_item_id']);
+                $result = $submittedItem['result'] ?? $trackingItem->result->value;
+                $rankingCount = array_key_exists('rankings', $submittedItem)
+                    ? count($submittedItem['rankings'])
+                    : $trackingItem->rankings->count();
+
+                if (array_key_exists('rankings', $submittedItem)) {
+                    $positions = collect($submittedItem['rankings'])->pluck('position');
+
+                    if ($positions->unique()->count() !== $positions->count()) {
+                        return [
+                            'status' => false,
+                            'error' => 'As posições da classificação não podem se repetir no mesmo item.',
+                            'statusCode' => 400,
+                        ];
+                    }
+                }
+
+                if (
+                    $result === ProposalTrackingItemResult::Pending->value
+                    && array_key_exists('rankings', $submittedItem)
+                    && count($submittedItem['rankings']) > 0
+                ) {
+                    return [
+                        'status' => false,
+                        'error' => 'Itens pendentes não podem possuir classificação.',
+                        'statusCode' => 400,
+                    ];
+                }
+
+                if ($result !== ProposalTrackingItemResult::Pending->value && $rankingCount === 0) {
+                    return [
+                        'status' => false,
+                        'error' => 'Informe ao menos uma posição ao classificar um item como vencedor ou perdido.',
+                        'statusCode' => 400,
+                    ];
+                }
+            }
+
+            DB::transaction(function () use ($tracking, $data, $submittedItems, $trackingItems) {
+                if (array_key_exists('discount_percentage', $data)) {
+                    $tracking->discount_percentage = $data['discount_percentage'];
+                }
+
+                $tracking->last_updated_by = Auth::id();
+                $tracking->save();
+
+                foreach ($submittedItems as $submittedItem) {
+                    $trackingItem = $trackingItems->get($submittedItem['proposal_item_id']);
+
+                    if (! $trackingItem) {
+                        continue;
+                    }
+
+                    if (array_key_exists('minimum_unit_price', $submittedItem)) {
+                        $trackingItem->minimum_unit_price = $submittedItem['minimum_unit_price'];
+                    }
+
+                    if (array_key_exists('result', $submittedItem)) {
+                        $trackingItem->result = $submittedItem['result'];
+
+                        if ($submittedItem['result'] === ProposalTrackingItemResult::Pending->value) {
+                            $trackingItem->classified_at = null;
+                            $trackingItem->classified_by = null;
+                            $trackingItem->rankings()->delete();
+                        } else {
+                            $trackingItem->classified_at = now();
+                            $trackingItem->classified_by = Auth::id();
+                        }
+                    }
+
+                    if (array_key_exists('rankings', $submittedItem)) {
+                        $trackingItem->rankings()->delete();
+                        $trackingItem->rankings()->createMany(
+                            collect($submittedItem['rankings'])
+                                ->sortBy('position')
+                                ->values()
+                                ->all()
+                        );
+                    }
+
+                    $trackingItem->save();
+                }
+            });
+
+            return [
+                'status' => true,
+                'data' => $this->payload($proposal->fresh(), $tracking->fresh()),
+            ];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta não encontrada.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function applyDiscount($request, int $proposalId): array
+    {
+        try {
+            $validator = Validator::make($request->all(), [
+                'discount_percentage' => ['required', 'numeric', 'min:0', 'max:100'],
+            ]);
+
+            if ($validator->fails()) {
+                return ['status' => false, 'error' => $validator->errors(), 'statusCode' => 400];
+            }
+
+            $proposal = $this->findUserProposal($proposalId);
+            $tracking = $this->ensureTracking($proposal);
+
+            if ($tracking->status === ProposalTrackingStatus::Finished) {
+                return [
+                    'status' => false,
+                    'error' => 'O acompanhamento está finalizado. Reabra-o antes de editar.',
+                    'statusCode' => 409,
+                ];
+            }
+
+            $percentage = $validator->validated()['discount_percentage'];
+
+            DB::transaction(function () use ($tracking, $percentage) {
+                $tracking->update([
+                    'discount_percentage' => $percentage,
+                    'last_updated_by' => Auth::id(),
+                ]);
+
+                $tracking->load('items.proposalItem');
+
+                foreach ($tracking->items as $trackingItem) {
+                    $trackingItem->minimum_unit_price = $this->discountedUnitPrice(
+                        $trackingItem->proposalItem->unit_price,
+                        $percentage
+                    );
+                    $trackingItem->save();
+                }
+            });
+
+            return [
+                'status' => true,
+                'data' => $this->payload($proposal->fresh(), $tracking->fresh()),
+            ];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta não encontrada.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    public function finish(int $proposalId): array
+    {
+        return $this->changeStatus($proposalId, ProposalTrackingStatus::Finished);
+    }
+
+    public function reopen(int $proposalId): array
+    {
+        return $this->changeStatus($proposalId, ProposalTrackingStatus::Open);
+    }
+
+    public function printData(int $proposalId): array
+    {
+        $result = $this->get($proposalId);
+
+        if (! $result['status']) {
+            return $result;
+        }
+
+        $result['data']['document'] = [
+            'title' => 'Acompanhamento de Licitação',
+            'generated_at' => now()->toISOString(),
+            'print_css_hint' => 'Ocultar controles interativos e imprimir o conteúdo em formato A4.',
+        ];
+
+        return $result;
+    }
+
+    public function export(int $proposalId): array
+    {
+        $result = $this->get($proposalId);
+
+        if (! $result['status']) {
+            return $result;
+        }
+
+        $stream = fopen('php://temp', 'w+');
+        fwrite($stream, "\xEF\xBB\xBF");
+        fputcsv($stream, [
+            'Item',
+            'Resultado',
+            'Quantidade',
+            'Unidade',
+            'Especificação',
+            'Marca',
+            'Preço unitário',
+            'Preço unitário mínimo',
+            'Valor total',
+            'Valor total mínimo',
+            'Empresa 1º lugar',
+            'Marca 1º lugar',
+            'Preço 1º lugar',
+            'Empresa 2º lugar',
+            'Marca 2º lugar',
+            'Preço 2º lugar',
+            'Empresa 3º lugar',
+            'Marca 3º lugar',
+            'Preço 3º lugar',
+        ], ';');
+
+        foreach ($result['data']['items'] as $item) {
+            $rankings = collect($item['rankings'])->keyBy('position');
+            fputcsv($stream, [
+                $item['item'],
+                $item['result'],
+                $item['quantity'],
+                $item['unit'],
+                $item['specification'],
+                $item['brand'],
+                $item['unit_price'],
+                $item['minimum_unit_price'],
+                $item['total_value'],
+                $item['minimum_total_value'],
+                $rankings->get(1)['company'] ?? null,
+                $rankings->get(1)['brand'] ?? null,
+                $rankings->get(1)['price'] ?? null,
+                $rankings->get(2)['company'] ?? null,
+                $rankings->get(2)['brand'] ?? null,
+                $rankings->get(2)['price'] ?? null,
+                $rankings->get(3)['company'] ?? null,
+                $rankings->get(3)['brand'] ?? null,
+                $rankings->get(3)['price'] ?? null,
+            ], ';');
+        }
+
+        fputcsv($stream, [], ';');
+        fputcsv($stream, ['Total original', $result['data']['totals']['original']], ';');
+        fputcsv($stream, ['Total mínimo', $result['data']['totals']['minimum']], ';');
+        fputcsv($stream, ['Total ganho', $result['data']['totals']['won']], ';');
+
+        rewind($stream);
+        $content = stream_get_contents($stream);
+        fclose($stream);
+
+        return [
+            'status' => true,
+            'data' => [
+                'filename' => "acompanhamento-proposta-{$proposalId}.csv",
+                'content' => $content,
+            ],
+        ];
+    }
+
+    private function changeStatus(int $proposalId, ProposalTrackingStatus $status): array
+    {
+        try {
+            $proposal = $this->findUserProposal($proposalId);
+            $tracking = $this->ensureTracking($proposal);
+            $tracking->update([
+                'status' => $status->value,
+                'last_updated_by' => Auth::id(),
+                'finished_at' => $status === ProposalTrackingStatus::Finished ? now() : null,
+            ]);
+
+            return ['status' => true, 'data' => $this->payload($proposal, $tracking->fresh())];
+        } catch (ModelNotFoundException) {
+            return ['status' => false, 'error' => 'Proposta não encontrada.', 'statusCode' => 404];
+        } catch (Exception $error) {
+            return ['status' => false, 'error' => $error->getMessage(), 'statusCode' => 400];
+        }
+    }
+
+    private function ensureTracking(Proposal $proposal): ProposalTracking
+    {
+        return DB::transaction(function () use ($proposal) {
+            $tracking = ProposalTracking::firstOrCreate(
+                ['proposal_id' => $proposal->id],
+                [
+                    'status' => ProposalTrackingStatus::Open->value,
+                    'last_updated_by' => Auth::id(),
+                ]
+            );
+
+            $existingItemIds = $tracking->items()->pluck('proposal_item_id');
+            $missingItems = $proposal->items()->whereNotIn('id', $existingItemIds)->get();
+
+            if ($missingItems->isNotEmpty()) {
+                $tracking->items()->createMany($missingItems->map(fn (ProposalItem $item) => [
+                    'proposal_item_id' => $item->id,
+                    'result' => ProposalTrackingItemResult::Pending->value,
+                ])->all());
+            }
+
+            return $tracking;
+        });
+    }
+
+    private function payload(Proposal $proposal, ProposalTracking $tracking): array
+    {
+        $proposal->loadMissing(['items', 'company', 'tender']);
+        $tracking->load(['items.proposalItem', 'items.rankings']);
+
+        $trackingByProposalItem = $tracking->items->keyBy('proposal_item_id');
+        $items = $proposal->items->map(function (ProposalItem $proposalItem) use ($trackingByProposalItem) {
+            /** @var ProposalTrackingItem $trackingItem */
+            $trackingItem = $trackingByProposalItem->get($proposalItem->id);
+            $minimumTotal = $this->multiplyDecimals(
+                $proposalItem->quantity,
+                $trackingItem?->minimum_unit_price,
+                2
+            );
+
+            return [
+                'proposal_item_id' => $proposalItem->id,
+                'item' => $proposalItem->item,
+                'quantity' => $proposalItem->quantity,
+                'unit' => $proposalItem->unit,
+                'specification' => $proposalItem->specification,
+                'brand' => $proposalItem->brand,
+                'unit_price' => $proposalItem->unit_price,
+                'total_value' => $proposalItem->total_value,
+                'result' => $trackingItem?->result?->value ?? ProposalTrackingItemResult::Pending->value,
+                'minimum_unit_price' => $trackingItem?->minimum_unit_price,
+                'minimum_total_value' => $minimumTotal,
+                'rankings' => ($trackingItem?->rankings ?? collect())
+                    ->sortBy('position')
+                    ->map(fn ($ranking) => [
+                        'id' => $ranking->id,
+                        'position' => $ranking->position,
+                        'company' => $ranking->company,
+                        'brand' => $ranking->brand,
+                        'price' => $ranking->price,
+                    ])
+                    ->values()
+                    ->all() ?? [],
+                'classified_at' => $trackingItem?->classified_at?->toISOString(),
+                'classified_by' => $trackingItem?->classified_by,
+            ];
+        })->values();
+
+        $minimumTotal = $items->sum(fn ($item) => (float) ($item['minimum_total_value'] ?? 0));
+        $wonTotal = $items
+            ->where('result', ProposalTrackingItemResult::Won->value)
+            ->sum(fn ($item) => (float) ($item['minimum_total_value'] ?? 0));
+
+        return [
+            'proposal' => $proposal,
+            'company' => $proposal->company_snapshot ?? $proposal->company,
+            'tender' => $proposal->tender_snapshot ?? $proposal->tender,
+            'tracking' => [
+                'id' => $tracking->id,
+                'status' => $tracking->status->value,
+                'discount_percentage' => $tracking->discount_percentage,
+                'last_updated_by' => $tracking->last_updated_by,
+                'finished_at' => $tracking->finished_at?->toISOString(),
+                'created_at' => $tracking->created_at?->toISOString(),
+                'updated_at' => $tracking->updated_at?->toISOString(),
+            ],
+            'items' => $items->all(),
+            'totals' => [
+                'original' => $this->formatDecimal($proposal->total_value ?? $items->sum('total_value'), 2),
+                'minimum' => $this->formatDecimal($minimumTotal, 2),
+                'won' => $this->formatDecimal($wonTotal, 2),
+            ],
+            'won_items' => $items
+                ->where('result', ProposalTrackingItemResult::Won->value)
+                ->values()
+                ->all(),
+            'declarations' => $proposal->declarations,
+            'signature' => [
+                'responsible_name' => $proposal->responsible_name,
+                'responsible_rg' => $proposal->responsible_rg,
+                'responsible_cpf' => $proposal->responsible_cpf,
+                'city' => $proposal->city,
+                'proposal_date' => $proposal->proposal_date?->format('Y-m-d'),
+            ],
+        ];
+    }
+
+    private function findUserProposal(int $proposalId): Proposal
+    {
+        return Proposal::query()
+            ->where('user_id', Auth::id())
+            ->findOrFail($proposalId);
+    }
+
+    private function discountedUnitPrice($unitPrice, $percentage): ?string
+    {
+        if ($unitPrice === null) {
+            return null;
+        }
+
+        $unitPriceScaled = $this->decimalToScaledInteger($unitPrice, 4);
+        $percentageScaled = $this->decimalToScaledInteger($percentage, 4);
+        $factorScaled = 1000000 - $percentageScaled;
+        $discounted = (int) round(($unitPriceScaled * $factorScaled) / 1000000);
+
+        return $this->scaledIntegerToDecimal($discounted, 4);
+    }
+
+    private function multiplyDecimals($left, $right, int $resultScale): ?string
+    {
+        if ($left === null || $right === null) {
+            return null;
+        }
+
+        $leftScaled = $this->decimalToScaledInteger($left, 4);
+        $rightScaled = $this->decimalToScaledInteger($right, 4);
+        $divisor = 10 ** (8 - $resultScale);
+        $result = (int) round(($leftScaled * $rightScaled) / $divisor);
+
+        return $this->scaledIntegerToDecimal($result, $resultScale);
+    }
+
+    private function decimalToScaledInteger($value, int $scale): int
+    {
+        $normalized = number_format((float) $value, $scale, '.', '');
+        $negative = str_starts_with($normalized, '-');
+        $normalized = ltrim($normalized, '-');
+        [$integer, $fraction] = array_pad(explode('.', $normalized, 2), 2, '');
+        $scaled = (int) ($integer.str_pad(substr($fraction, 0, $scale), $scale, '0'));
+
+        return $negative ? -$scaled : $scaled;
+    }
+
+    private function scaledIntegerToDecimal(int $value, int $scale): string
+    {
+        $negative = $value < 0;
+        $digits = str_pad((string) abs($value), $scale + 1, '0', STR_PAD_LEFT);
+        $decimal = substr($digits, 0, -$scale).'.'.substr($digits, -$scale);
+
+        return ($negative ? '-' : '').$decimal;
+    }
+
+    private function formatDecimal($value, int $scale): string
+    {
+        return number_format((float) $value, $scale, '.', '');
+    }
+}

--- a/app/Services/Tender/TenderService.php
+++ b/app/Services/Tender/TenderService.php
@@ -237,13 +237,16 @@ class TenderService
                         $query->whereIn('status', $statuses);
                     }
                 })
-                ->orderBy('bid_opening_date')
                 ->get()
                 ->map(function ($tender) {
-                    $tender->calendar_status = $tender->calendarTenders->first()?->status?->value;
+                    $calendarTender = $tender->calendarTenders->first();
+                    $tender->calendar_status = $calendarTender?->status?->value;
+                    $tender->calendar_date = $calendarTender?->calendar_date;
 
                     return $tender;
-                });
+                })
+                ->sortBy(fn ($tender) => $tender->calendar_date ?? $tender->bid_opening_date)
+                ->values();
 
             return ['status' => true, 'data' => $tenders];
         } catch (Exception $error) {
@@ -256,13 +259,14 @@ class TenderService
         try {
             $validator = Validator::make($request->all(), [
                 'status' => ['nullable', new Enum(CalendarTenderStatus::class)],
+                'calendar_date' => ['nullable', 'date'],
             ]);
 
             if ($validator->fails()) {
                 return ['status' => false, 'error' => $validator->errors(), 'statusCode' => 400];
             }
 
-            Tender::findOrFail($tender_id);
+            $tender = Tender::findOrFail($tender_id);
 
             $user = Auth::user();
             $calendarTender = CalendarTender::where('tender_id', $tender_id)
@@ -270,11 +274,18 @@ class TenderService
                 ->first();
 
             if ($calendarTender) {
-                if ($request->filled('status')) {
-                    $calendarTender->status = $request->input('status');
+                if ($request->filled('status') || $request->has('calendar_date')) {
+                    if ($request->filled('status')) {
+                        $calendarTender->status = $request->input('status');
+                    }
+
+                    if ($request->has('calendar_date')) {
+                        $calendarTender->calendar_date = $request->input('calendar_date');
+                    }
+
                     $calendarTender->save();
 
-                    return ['status' => true, 'data' => ['marked' => true, 'calendar_status' => $calendarTender->status->value]];
+                    return ['status' => true, 'data' => $this->calendarTenderResponse($calendarTender)];
                 }
 
                 CalendarTender::where('tender_id', $tender_id)
@@ -288,12 +299,22 @@ class TenderService
                 'tender_id' => $tender_id,
                 'user_id' => $user->id,
                 'status' => $request->input('status', CalendarTenderStatus::Participating->value),
+                'calendar_date' => $request->input('calendar_date', $tender->bid_opening_date),
             ]);
 
-            return ['status' => true, 'data' => ['marked' => true, 'calendar_status' => $calendarTender->status->value]];
+            return ['status' => true, 'data' => $this->calendarTenderResponse($calendarTender)];
         } catch (Exception $error) {
             return ['status' => false, 'error' => $error->getMessage()];
         }
+    }
+
+    private function calendarTenderResponse(CalendarTender $calendarTender): array
+    {
+        return [
+            'marked' => true,
+            'calendar_status' => $calendarTender->status->value,
+            'calendar_date' => $calendarTender->calendar_date?->toISOString(),
+        ];
     }
 
     public function createAll($tendersData)

--- a/app/Services/Tender/TenderService.php
+++ b/app/Services/Tender/TenderService.php
@@ -101,6 +101,19 @@ class TenderService
                 $tenders->where('observations', 'LIKE', "%$observations%");
             }
 
+            if ($request->filled('origin_domains')) {
+                $originDomains = $this->normalizeListFilter($request->input('origin_domains'));
+
+                if (! empty($originDomains)) {
+                    $tenders->where(function ($query) use ($originDomains) {
+                        foreach ($originDomains as $originDomain) {
+                            $escapedDomain = addcslashes($originDomain, '\\%_');
+                            $query->orWhere('origin_url', 'LIKE', $escapedDomain.'%');
+                        }
+                    });
+                }
+            }
+
             if ($request->input('proposal_closing_date_start') && $request->input('proposal_closing_date_end')) {
                 if($request->proposal_closing_date_start == $request->proposal_closing_date_end){
                     $tenders->whereDate('proposal_closing_date_start', $request->proposal_closing_date_start);
@@ -155,6 +168,16 @@ class TenderService
         } catch (Exception $error) {
             return ['status' => false, 'error' => $error->getMessage()];
         }
+    }
+
+    private function normalizeListFilter(array|string $value): array
+    {
+        $values = is_array($value) ? $value : explode(',', $value);
+
+        return array_values(array_unique(array_filter(
+            array_map(fn ($item) => trim((string) $item), $values),
+            fn ($item) => $item !== ''
+        )));
     }
 
     public function delete($tender_id){

--- a/database/migrations/2026_07_15_000001_add_calendar_date_to_calendar_tenders_table.php
+++ b/database/migrations/2026_07_15_000001_add_calendar_date_to_calendar_tenders_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('calendar_tenders', 'calendar_date')) {
+            return;
+        }
+
+        Schema::table('calendar_tenders', function (Blueprint $table) {
+            $table->dateTime('calendar_date')->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('calendar_tenders', 'calendar_date')) {
+            return;
+        }
+
+        Schema::table('calendar_tenders', function (Blueprint $table) {
+            $table->dropColumn('calendar_date');
+        });
+    }
+};

--- a/database/migrations/2026_07_15_000002_create_proposal_trackings_tables.php
+++ b/database/migrations/2026_07_15_000002_create_proposal_trackings_tables.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('proposal_trackings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('proposal_id')->unique()->constrained()->cascadeOnDelete();
+            $table->decimal('discount_percentage', 7, 4)->nullable();
+            $table->string('status')->default('open');
+            $table->foreignId('last_updated_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('finished_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('proposal_tracking_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('proposal_tracking_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('proposal_item_id')->constrained()->cascadeOnDelete();
+            $table->string('result')->default('pending');
+            $table->decimal('minimum_unit_price', 15, 4)->nullable();
+            $table->unsignedInteger('classification_position')->nullable();
+            $table->timestamp('classified_at')->nullable();
+            $table->foreignId('classified_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['proposal_tracking_id', 'proposal_item_id'], 'tracking_proposal_item_unique');
+            $table->index(['proposal_tracking_id', 'result']);
+        });
+
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('proposal_tracking_items');
+        Schema::dropIfExists('proposal_trackings');
+    }
+};

--- a/database/migrations/2026_07_15_000003_replace_tracking_classification_position_with_rankings.php
+++ b/database/migrations/2026_07_15_000003_replace_tracking_classification_position_with_rankings.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // MySQL may leave the table behind when adding a constraint fails during
+        // Schema::create, even though Laravel does not record the migration.
+        Schema::dropIfExists('proposal_tracking_item_rankings');
+
+        Schema::create('proposal_tracking_item_rankings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('proposal_tracking_item_id');
+            $table->unsignedTinyInteger('position');
+            $table->string('company');
+            $table->string('brand')->nullable();
+            $table->decimal('price', 15, 4);
+            $table->timestamps();
+
+            $table->foreign('proposal_tracking_item_id', 'tracking_ranking_item_fk')
+                ->references('id')
+                ->on('proposal_tracking_items')
+                ->cascadeOnDelete();
+            $table->unique(['proposal_tracking_item_id', 'position'], 'tracking_item_position_unique');
+        });
+
+        Schema::table('proposal_tracking_items', function (Blueprint $table) {
+            $table->dropColumn('classification_position');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('proposal_tracking_items', function (Blueprint $table) {
+            $table->unsignedInteger('classification_position')->nullable()->after('minimum_unit_price');
+        });
+
+        Schema::dropIfExists('proposal_tracking_item_rankings');
+    }
+};

--- a/database/migrations/2026_07_15_000004_create_proposal_catalogs_tables.php
+++ b/database/migrations/2026_07_15_000004_create_proposal_catalogs_tables.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('proposal_catalogs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('proposal_id')->unique();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('company_id')->nullable();
+            $table->string('title')->default('Catálogo de Produtos');
+            $table->string('subtitle')->nullable();
+            $table->longText('general_notes')->nullable();
+            $table->string('organ_name')->nullable();
+            $table->string('organ_state')->nullable();
+            $table->string('purchase_number')->nullable();
+            $table->string('process_number')->nullable();
+            $table->date('receipt_date')->nullable();
+            $table->date('opening_date')->nullable();
+            $table->json('company_snapshot')->nullable();
+            $table->unsignedBigInteger('last_updated_by')->nullable();
+            $table->timestamp('generated_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('proposal_id', 'catalog_proposal_fk')
+                ->references('id')->on('proposals')->cascadeOnDelete();
+            $table->foreign('user_id', 'catalog_user_fk')
+                ->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('company_id', 'catalog_company_fk')
+                ->references('id')->on('companies')->nullOnDelete();
+            $table->foreign('last_updated_by', 'catalog_updated_by_fk')
+                ->references('id')->on('users')->nullOnDelete();
+        });
+
+        Schema::create('proposal_catalog_items', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('proposal_catalog_id');
+            $table->unsignedBigInteger('proposal_item_id')->nullable();
+            $table->string('title')->nullable();
+            $table->longText('specification')->nullable();
+            $table->decimal('quantity', 15, 4)->nullable();
+            $table->string('unit')->nullable();
+            $table->string('brand')->nullable();
+            $table->unsignedInteger('position');
+            $table->string('image_path')->nullable();
+            $table->string('image_original_name')->nullable();
+            $table->string('image_mime', 100)->nullable();
+            $table->timestamps();
+
+            $table->foreign('proposal_catalog_id', 'catalog_item_catalog_fk')
+                ->references('id')->on('proposal_catalogs')->cascadeOnDelete();
+            $table->foreign('proposal_item_id', 'catalog_item_proposal_item_fk')
+                ->references('id')->on('proposal_items')->nullOnDelete();
+            $table->unique(['proposal_catalog_id', 'position'], 'catalog_item_position_unique');
+            $table->unique(['proposal_catalog_id', 'proposal_item_id'], 'catalog_proposal_item_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('proposal_catalog_items');
+        Schema::dropIfExists('proposal_catalogs');
+    }
+};

--- a/docs/acompanhamento-de-propostas.md
+++ b/docs/acompanhamento-de-propostas.md
@@ -1,0 +1,675 @@
+# Acompanhamento de propostas
+
+## Objetivo
+
+Este documento registra o funcionamento observado na tela de acompanhamento de propostas do sistema **Localizador de Editais** e transforma a referência visual em requisitos para uma futura implementação no Licitador.
+
+> **Status no Licitador:** backend implementado. Este arquivo também é o contrato de integração para a implementação do frontend.
+
+A análise foi realizada em 15/07/2026, em uma sessão autenticada fornecida pelo usuário, a partir da listagem **Minhas Propostas** e da ação **Acompanhamento**.
+
+URL observada:
+
+```text
+https://painel.localizadordeeditais.com.br/wp-admin/admin-ajax.php?action=gpl_valor_minimo&id={proposal_id}
+```
+
+O parâmetro `id` identifica a proposta que será acompanhada.
+
+## Fluxo de acesso
+
+1. O usuário acessa a página **Minhas Propostas**.
+2. A página apresenta pesquisa textual, filtro por empresa e uma tabela paginada de propostas.
+3. Cada proposta possui as ações:
+   - Visualizar;
+   - Editar;
+   - Excluir;
+   - Acompanhamento;
+   - Criar catálogo (Beta).
+4. Ao selecionar **Acompanhamento**, uma nova aba é aberta com o acompanhamento da proposta selecionada.
+
+## Estrutura da tela de acompanhamento
+
+### Cabeçalho
+
+O topo funciona como cabeçalho de um documento comercial e contém:
+
+- logotipo da plataforma;
+- razão social da empresa participante;
+- endereço da empresa;
+- CNPJ;
+- telefone;
+- e-mail.
+
+Os dados pertencem à empresa vinculada à proposta e não são editados diretamente nessa tela.
+
+### Ações fixas
+
+No canto superior direito existe um bloco flutuante, que permanece disponível durante a rolagem, com quatro ações:
+
+- **Salvar**: persiste preços mínimos e classificações registradas;
+- **Imprimir**: abre o fluxo de impressão do acompanhamento/documento;
+- **Exportar Excel**: gera uma planilha com os dados do acompanhamento;
+- **Fechar**: fecha a tela e retorna ao contexto anterior.
+
+As ações de salvar, imprimir e exportar foram identificadas visualmente, mas não foram executadas para evitar alterações ou geração de artefatos no sistema de referência.
+
+### Identificação da licitação
+
+Abaixo do título **Acompanhamento de Licitação**, a tela apresenta uma linha resumida contendo:
+
+- órgão;
+- estado (UF);
+- número da compra;
+- número do processo.
+
+Essas informações vêm da licitação associada à proposta.
+
+## Regras de preço mínimo
+
+A tela diferencia os valores utilizando uma legenda por cores:
+
+- **Preço unitário mínimo**: campo editável;
+- **Valor total mínimo**: valor calculado;
+- **Vencedor**: classificação positiva do item;
+- **Perdeu**: classificação negativa do item.
+
+### Desconto em lote
+
+Existe um controle **Aplicar desconto**, composto por:
+
+- campo numérico percentual;
+- indicação de `%`;
+- botão **Aplicar em todos**;
+- texto auxiliar com exemplo do cálculo do preço unitário.
+
+O objetivo é calcular e preencher o preço unitário mínimo de todos os itens usando um percentual de desconto sobre o preço unitário da proposta.
+
+Regra funcional esperada:
+
+```text
+preco_unitario_minimo = preco_unitario_proposta * (1 - percentual_desconto / 100)
+valor_total_minimo = preco_unitario_minimo * quantidade
+```
+
+O preço mínimo continua editável individualmente depois da aplicação em lote.
+
+## Grade de itens
+
+Cada item da proposta é exibido em uma tabela com as seguintes colunas:
+
+| Coluna | Comportamento observado |
+|---|---|
+| Item | Código ou número do item na licitação |
+| Resultado | Controles Vencedor e Perdeu |
+| Qtd | Quantidade proposta |
+| Unid. | Unidade de fornecimento |
+| Especificação | Descrição completa do produto ou serviço |
+| Marca | Marca informada na proposta |
+| Preço Unit. | Preço unitário original da proposta |
+| Preço Unit. Min. | Campo editável para registrar o menor preço aceitável |
+| Valor Total | Quantidade multiplicada pelo preço unitário original |
+| Valor Total Min. | Quantidade multiplicada pelo preço unitário mínimo |
+
+No rodapé da tabela existe uma linha **Total geral**, contendo pelo menos:
+
+- soma dos valores totais originais;
+- soma dos valores totais mínimos.
+
+### Classificação do item
+
+Para cada item o usuário pode registrar um resultado:
+
+- **Vencedor**;
+- **Perdeu**;
+- sem classificação.
+
+Visualmente, os controles são apresentados como seleções independentes próximas ao item. Para nossa implementação, devem funcionar como estados mutuamente exclusivos: um item não pode estar simultaneamente como vencedor e perdido.
+
+Estado sugerido para o backend:
+
+```text
+pending | won | lost
+```
+
+Ao clicar em **Vencedor** ou **Perdeu**, o sistema de referência expande abaixo do item o formulário **Classificação do Item**, com três colocações:
+
+| Posição | Campos |
+|---|---|
+| 1º lugar | Empresa, Marca e Preço |
+| 2º lugar | Empresa, Marca e Preço |
+| 3º lugar | Empresa, Marca e Preço |
+
+No sistema de referência, ao marcar Vencedor, o primeiro lugar é preenchido automaticamente com a empresa da própria proposta. No Licitador, esse preenchimento automático é responsabilidade do frontend. O backend apenas valida e persiste a classificação recebida.
+
+## Relatório de itens ganhos
+
+Logo após a tabela existe uma área verde intitulada **Relatório de Itens Ganhos**.
+
+Quando nenhum item foi classificado como vencedor, a seção apresenta a mensagem:
+
+```text
+Nenhum item marcado como vencedor ainda.
+```
+
+A posição e a mensagem indicam que essa seção é atualizada a partir da classificação dos itens e deve reunir somente os itens vencedores. A composição detalhada do relatório com itens vencedores não foi validada, pois não foram salvas alterações na proposta de referência.
+
+Para o Licitador, o relatório deve apresentar:
+
+- item;
+- descrição;
+- quantidade;
+- unidade;
+- marca;
+- preço unitário final;
+- valor total final;
+- total geral ganho.
+
+## Rodapé documental
+
+Depois do relatório, a tela assume formato de documento comercial e apresenta:
+
+- validade da proposta, indicada como de acordo com o edital;
+- bloco de declarações do fornecedor;
+- confirmação de ciência do instrumento convocatório;
+- concordância com exigências, condições e solicitações do edital;
+- declaração de que o preço inclui custos diretos e indiretos;
+- declaração sobre critérios de julgamento, medição e pagamento;
+- indicação de validade da proposta e forma de pagamento;
+- dados bancários para pagamento;
+- identificação e assinatura da empresa;
+- cidade e data de emissão.
+
+Os dados bancários e cadastrais são carregados da empresa vinculada à proposta. Informações sensíveis não foram reproduzidas neste documento.
+
+## Comportamento esperado no Licitador
+
+### Criação do acompanhamento
+
+- Cada proposta deve possuir no máximo um acompanhamento ativo.
+- O acompanhamento deve reutilizar os itens e valores da proposta sem duplicar ou alterar o orçamento original.
+- Na primeira abertura, todos os itens devem começar com resultado `pending`.
+- O preço unitário mínimo pode iniciar vazio ou com o preço original, conforme decisão de produto.
+
+### Edição
+
+O usuário deve poder:
+
+- informar um percentual e aplicá-lo a todos os itens;
+- editar o preço unitário mínimo de um item;
+- marcar o item como vencedor;
+- marcar o item como perdido;
+- remover a classificação, retornando o item para pendente;
+- salvar o acompanhamento e retomá-lo posteriormente.
+
+Alterações no acompanhamento não devem modificar os itens e preços originais da proposta.
+
+### Cálculos
+
+- Os totais mínimos devem ser recalculados quando o preço mínimo for alterado.
+- Valores monetários devem ser calculados no backend com precisão decimal.
+- O total geral ganho deve considerar apenas itens vencedores.
+- A aplicação de desconto deve ocorrer sobre o preço unitário original, evitando descontos cumulativos a cada clique.
+
+### Permissões
+
+- Somente usuários autorizados da empresa proprietária da proposta podem consultar ou editar o acompanhamento.
+- Visualização, edição, impressão e exportação devem respeitar as mesmas regras de acesso da proposta.
+- O backend não deve confiar apenas no identificador recebido na URL.
+
+## Dados necessários
+
+O acompanhamento precisa registrar, no mínimo:
+
+### Acompanhamento
+
+- proposta;
+- percentual de desconto aplicado, quando houver;
+- validade da proposta;
+- observações ou declarações, caso sejam futuramente editáveis;
+- usuário responsável pela última alteração;
+- datas de criação e atualização.
+
+### Itens acompanhados
+
+- item da proposta;
+- resultado (`pending`, `won` ou `lost`);
+- preço unitário mínimo;
+- valor total mínimo calculado;
+- data da classificação;
+- usuário responsável pela classificação.
+
+### Colocações do item
+
+- item acompanhado;
+- posição entre `1` e `3`;
+- nome da empresa;
+- marca;
+- preço ofertado.
+
+Cada posição pode aparecer apenas uma vez por item. A classificação é uma lista independente para cada item da proposta.
+
+Os dados descritivos do item, quantidade, unidade, marca e preço original devem continuar vindo do item da proposta.
+
+## Endpoints implementados
+
+Todos os endpoints abaixo exigem a mesma autenticação JWT das demais rotas protegidas da API.
+
+```text
+GET  /api/proposal/{proposal_id}/tracking
+PUT  /api/proposal/{proposal_id}/tracking
+POST /api/proposal/{proposal_id}/tracking/apply-discount
+POST /api/proposal/{proposal_id}/tracking/finish
+POST /api/proposal/{proposal_id}/tracking/reopen
+GET  /api/proposal/{proposal_id}/tracking/export
+GET  /api/proposal/{proposal_id}/tracking/print
+```
+
+O salvamento é feito em lote e ocorre dentro de uma transação.
+
+## Layout de referência
+
+A tela observada foi construída como uma folha/documento centralizado:
+
+- fundo externo cinza-claro;
+- conteúdo principal branco;
+- cabeçalho corporativo no topo;
+- título centralizado;
+- dados da licitação em uma faixa;
+- legenda e desconto antes da tabela;
+- tabela compacta com cabeçalho escuro;
+- campos editáveis destacados em amarelo;
+- valores calculados destacados em verde-claro;
+- relatório de ganhos em um painel verde;
+- declarações e assinatura na parte inferior;
+- botões de ação coloridos em um bloco flutuante à direita.
+
+Em telas menores, a tabela deve permitir rolagem horizontal. A impressão deve esconder controles interativos e preservar apenas o documento.
+
+## Decisões adotadas no backend
+
+1. O preço mínimo começa vazio (`null`).
+2. Os resultados possíveis são `pending`, `won` e `lost`.
+3. Tanto `won` quanto `lost` exigem a classificação completa do item, com uma a três posições.
+4. Declarações, assinatura e dados da empresa são somente leitura no acompanhamento e vêm da proposta.
+5. O backend fornece payload específico de impressão e exportação CSV compatível com Excel.
+6. São registrados usuário e data da classificação, além do usuário da última alteração geral.
+7. A autorização atual continua vinculada ao proprietário da proposta (`user_id`).
+8. O acompanhamento pode ser finalizado. Depois disso fica somente leitura até ser explicitamente reaberto.
+
+## Pontos que ainda precisam de decisão de produto
+
+Antes da implementação, devem ser confirmados:
+
+1. O histórico completo de todas as alterações precisa ser auditável ou os campos atuais de usuário/data são suficientes?
+2. Usuários diferentes poderão pertencer à mesma empresa e compartilhar acompanhamentos?
+3. A exportação precisa evoluir de CSV compatível com Excel para `.xlsx` nativo?
+4. A impressão será feita diretamente pelo navegador ou futuramente deverá existir um PDF gerado pelo backend?
+
+## Contrato de integração com o frontend
+
+Esta seção descreve o comportamento efetivamente implementado. Em caso de divergência com as seções de referência visual, esta seção deve prevalecer para a integração.
+
+### Envelope JSON
+
+As respostas JSON seguem o padrão:
+
+```json
+{
+  "status": true,
+  "message": null,
+  "data": {},
+  "error": null
+}
+```
+
+Em erros de validação, `error` pode ser um objeto contendo mensagens por campo. Nos demais erros, será uma string.
+
+### Abrir ou consultar acompanhamento
+
+```http
+GET /api/proposal/{proposal_id}/tracking
+```
+
+Na primeira chamada, o backend cria automaticamente um acompanhamento com status `open` e um registro `pending` para cada item atual da proposta. Chamadas posteriores retornam o mesmo acompanhamento.
+
+Se novos itens forem adicionados à proposta, a próxima consulta adiciona os registros de acompanhamento que estiverem faltando. Os valores originais da proposta não são modificados.
+
+Resposta resumida:
+
+```json
+{
+  "status": true,
+  "data": {
+    "proposal": {
+      "id": 7505,
+      "company_id": 10,
+      "tender_id": 20,
+      "total_value": "1281803.19"
+    },
+    "company": {
+      "corporate_reason": "Empresa exemplo",
+      "cnpj": "00.000.000/0000-00"
+    },
+    "tender": {
+      "organ_name": "Órgão exemplo",
+      "uf": "BA",
+      "number_purchase": "234",
+      "process": "1232321"
+    },
+    "tracking": {
+      "id": 1,
+      "status": "open",
+      "discount_percentage": null,
+      "last_updated_by": 5,
+      "finished_at": null,
+      "created_at": "2026-07-15T12:00:00.000000Z",
+      "updated_at": "2026-07-15T12:00:00.000000Z"
+    },
+    "items": [
+      {
+        "proposal_item_id": 15,
+        "item": "1",
+        "quantity": "2.0000",
+        "unit": "UN",
+        "specification": "Descrição do item",
+        "brand": "Marca",
+        "unit_price": "100.0000",
+        "total_value": "200.00",
+        "result": "pending",
+        "minimum_unit_price": null,
+        "minimum_total_value": null,
+        "rankings": [],
+        "classified_at": null,
+        "classified_by": null
+      }
+    ],
+    "totals": {
+      "original": "200.00",
+      "minimum": "0.00",
+      "won": "0.00"
+    },
+    "won_items": [],
+    "declarations": "Texto da proposta",
+    "signature": {
+      "responsible_name": "Responsável",
+      "responsible_rg": "...",
+      "responsible_cpf": "...",
+      "city": "Cidade",
+      "proposal_date": "2026-07-15"
+    }
+  }
+}
+```
+
+Todos os valores decimais são retornados como **strings**. O frontend deve preservá-los como valores decimais e formatá-los para moeda apenas na apresentação.
+
+### Salvar alterações
+
+```http
+PUT /api/proposal/{proposal_id}/tracking
+Content-Type: application/json
+```
+
+É possível enviar somente os campos e itens alterados:
+
+```json
+{
+  "discount_percentage": "10.0000",
+  "items": [
+    {
+      "proposal_item_id": 15,
+      "result": "won",
+      "minimum_unit_price": "90.0000",
+      "rankings": [
+        {
+          "position": 1,
+          "company": "Empresa da proposta",
+          "brand": "Marca A",
+          "price": "90.0000"
+        },
+        {
+          "position": 2,
+          "company": "Empresa concorrente",
+          "brand": "Marca B",
+          "price": "95.0000"
+        }
+      ]
+    },
+    {
+      "proposal_item_id": 16,
+      "result": "lost",
+      "minimum_unit_price": "45.5000",
+      "rankings": [
+        {
+          "position": 1,
+          "company": "Empresa concorrente",
+          "brand": "Marca C",
+          "price": "40.0000"
+        },
+        {
+          "position": 3,
+          "company": "Empresa da proposta",
+          "brand": "Marca A",
+          "price": "45.5000"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Regras:
+
+- `discount_percentage` é opcional, aceita `null` ou valor entre `0` e `100`;
+- `items` é opcional;
+- `proposal_item_id` é obrigatório em cada item enviado;
+- `result` aceita somente `pending`, `won` ou `lost`;
+- `minimum_unit_price` aceita `null` ou número maior ou igual a zero;
+- `rankings` é opcional em atualizações parciais, mas, quando enviado, substitui integralmente as colocações anteriores do item;
+- `rankings` aceita no máximo três registros;
+- `position` é obrigatória, aceita apenas `1`, `2` ou `3` e não pode se repetir dentro do mesmo item;
+- `company` é obrigatória e aceita até 255 caracteres;
+- `brand` é opcional e aceita até 255 caracteres;
+- `price` é obrigatório e deve ser maior ou igual a zero;
+- ao usar `pending`, o backend limpa data, usuário e todas as colocações automaticamente;
+- `won` e `lost` exigem ao menos uma colocação salva;
+- não é necessário preencher as três posições, mas cada posição enviada deve estar completa;
+- itens não enviados permanecem inalterados;
+- item pertencente a outra proposta é rejeitado;
+- os totais da resposta são sempre recalculados pelo backend.
+
+A resposta possui o mesmo formato completo do `GET`.
+
+### Aplicar desconto em todos os itens
+
+```http
+POST /api/proposal/{proposal_id}/tracking/apply-discount
+Content-Type: application/json
+```
+
+```json
+{
+  "discount_percentage": "10.0000"
+}
+```
+
+O percentual é obrigatório e deve estar entre `0` e `100`.
+
+O backend calcula novamente todos os preços mínimos usando sempre o preço unitário original:
+
+```text
+minimum_unit_price = unit_price * (1 - discount_percentage / 100)
+```
+
+Portanto, aplicar `10%` e depois `20%` resulta em `20%` sobre o preço original, e não em descontos cumulativos. A resposta já contém todos os itens e totais recalculados.
+
+O frontend pode simular o cálculo antes da confirmação, mas deve substituir seu estado pelos valores devolvidos pelo backend após a requisição.
+
+### Classificação dos itens
+
+Mapeamento recomendado para os controles:
+
+| Estado | Interface | Efeito |
+|---|---|---|
+| `pending` | Sem classificação | Limpa usuário, data e todas as colocações |
+| `won` | Vencedor | Abre classificação, inclui o item em `won_items` e no total `won` |
+| `lost` | Perdeu | Abre o mesmo formulário de classificação |
+
+Os controles Vencedor e Perdeu devem ser mutuamente exclusivos. Não usar dois booleanos independentes no estado do frontend; usar diretamente o campo `result`.
+
+O frontend deve montar o array `rankings`. Ao selecionar Vencedor, deve preencher localmente a primeira posição com:
+
+- `company`: razão social disponível em `data.company`;
+- `brand`: marca do item;
+- `price`: preço definido pelo fluxo da interface, normalmente o preço final ou mínimo do próprio item.
+
+O backend não identifica nem insere automaticamente a empresa da proposta em nenhuma colocação.
+
+### Finalizar
+
+```http
+POST /api/proposal/{proposal_id}/tracking/finish
+```
+
+Altera o status para `finished` e preenche `finished_at`. A partir desse momento:
+
+- consultas, impressão e exportação continuam permitidas;
+- atualização e aplicação de desconto retornam HTTP `409`;
+- o frontend deve desabilitar os campos e o botão Salvar.
+
+### Reabrir
+
+```http
+POST /api/proposal/{proposal_id}/tracking/reopen
+```
+
+Altera o status para `open`, limpa `finished_at` e libera novamente a edição.
+
+### Dados para impressão
+
+```http
+GET /api/proposal/{proposal_id}/tracking/print
+```
+
+Retorna o mesmo payload completo do acompanhamento, acrescido de:
+
+```json
+{
+  "document": {
+    "title": "Acompanhamento de Licitação",
+    "generated_at": "2026-07-15T12:00:00.000000Z",
+    "print_css_hint": "Ocultar controles interativos e imprimir o conteúdo em formato A4."
+  }
+}
+```
+
+Esse endpoint **não retorna PDF**. O frontend deve montar a visualização de impressão e usar a impressão do navegador. Na mídia `print`, deve ocultar botões, campos e controles de classificação.
+
+### Exportar
+
+```http
+GET /api/proposal/{proposal_id}/tracking/export
+```
+
+Retorna download com:
+
+```text
+Content-Type: text/csv; charset=UTF-8
+Content-Disposition: attachment; filename="acompanhamento-proposta-{proposal_id}.csv"
+```
+
+O arquivo usa:
+
+- UTF-8 com BOM;
+- separador `;`;
+- uma linha por item;
+- colunas de resultado, valores originais e mínimos;
+- empresa, marca e preço do primeiro, segundo e terceiro lugares;
+- totais original, mínimo e ganho ao final.
+
+No frontend, o download deve ser tratado como `blob`. Embora abra normalmente no Excel, o formato entregue atualmente é `.csv`, não `.xlsx`.
+
+### Códigos HTTP relevantes
+
+| Código | Situação |
+|---|---|
+| `200` | Operação concluída |
+| `400` | Payload inválido, item de outra proposta ou regra de validação violada |
+| `404` | Proposta inexistente ou pertencente a outro usuário |
+| `409` | Tentativa de editar um acompanhamento finalizado |
+
+### Estado recomendado no frontend
+
+O frontend deve manter:
+
+```ts
+type TrackingResult = 'pending' | 'won' | 'lost'
+type TrackingStatus = 'open' | 'finished'
+
+interface TrackingItem {
+  proposal_item_id: number
+  item: string | null
+  quantity: string | null
+  unit: string | null
+  specification: string | null
+  brand: string | null
+  unit_price: string | null
+  total_value: string | null
+  result: TrackingResult
+  minimum_unit_price: string | null
+  minimum_total_value: string | null
+  rankings: TrackingRanking[]
+  classified_at: string | null
+  classified_by: number | null
+}
+
+interface TrackingRanking {
+  id?: number
+  position: 1 | 2 | 3
+  company: string
+  brand: string | null
+  price: string
+}
+```
+
+Recomendações de integração:
+
+- carregar a tela sempre pelo `GET tracking`;
+- usar `proposal_item_id` como chave estável da linha;
+- manter as colocações isoladas por `proposal_item_id`;
+- ao abrir Vencedor ou Perdeu, editar uma cópia local das colocações e enviá-la em `rankings` ao salvar;
+- ao marcar Vencedor, preencher o primeiro lugar no frontend antes de abrir ou exibir o formulário;
+- não enviar linhas vazias da segunda ou terceira posição;
+- enviar apenas itens alterados no `PUT` ou enviar todas as linhas, pois ambos são aceitos;
+- substituir os itens e totais locais pela resposta de cada operação;
+- não calcular totais definitivos apenas no navegador;
+- exibir confirmação antes de finalizar;
+- oferecer Reabrir somente quando o status for `finished`;
+- apresentar erros por campo quando `error` for um objeto;
+- tratar `404` como recurso indisponível e `409` como estado somente leitura.
+
+## Arquivos do backend relacionados
+
+```text
+app/Enums/ProposalTrackingStatus.php
+app/Enums/ProposalTrackingItemResult.php
+app/Models/ProposalTracking.php
+app/Models/ProposalTrackingItem.php
+app/Models/ProposalTrackingItemRanking.php
+app/Services/Proposal/ProposalTrackingService.php
+app/Http/Controllers/ProposalTrackingController.php
+database/migrations/2026_07_15_000002_create_proposal_trackings_tables.php
+database/migrations/2026_07_15_000003_replace_tracking_classification_position_with_rankings.php
+routes/api.php
+tests/Feature/ProposalTest.php
+```
+
+## Limites desta análise
+
+- Nenhuma alteração foi salva no sistema de referência.
+- As ações Imprimir e Exportar Excel não foram executadas.
+- O conteúdo exato do relatório com itens vencedores não foi validado.
+- Regras internas de arredondamento, persistência e autorização não podem ser determinadas apenas pela interface e deverão ser definidas no Licitador.
+
+Esses limites dizem respeito somente ao sistema usado como referência visual. O comportamento efetivamente implementado no Licitador está definido na seção **Contrato de integração com o frontend**.

--- a/docs/catalogo-de-propostas.md
+++ b/docs/catalogo-de-propostas.md
@@ -1,0 +1,603 @@
+# Catálogo de propostas
+
+## Objetivo
+
+Este documento registra o funcionamento e o layout observados na funcionalidade **Criar catálogo (Beta)** do sistema **Localizador de Editais** e define o contrato implementado no backend do Licitador.
+
+> **Status no Licitador:** backend implementado. Este arquivo é também o contrato de integração para o agente responsável pelo frontend.
+
+A análise foi realizada em 15/07/2026, usando uma sessão autenticada fornecida pelo usuário. Foram avaliados a abertura do catálogo a partir de **Minhas Propostas**, o formulário de montagem, a visualização gerada, o modo de edição da visualização e o fluxo de impressão.
+
+URLs observadas:
+
+```text
+Edição:      https://painel.localizadordeeditais.com.br/?gpl_catalogo_from_proposta={proposal_id}
+Visualização: https://painel.localizadordeeditais.com.br/?gpl_view_catalogo={catalog_id}
+```
+
+O parâmetro `proposal_id` identifica a proposta usada como origem. Depois da criação, a visualização utiliza um identificador próprio do catálogo, `catalog_id`.
+
+Informações cadastrais sensíveis da empresa visualizada não foram reproduzidas neste documento.
+
+## Fluxo de acesso
+
+1. O usuário acessa a página **Minhas Propostas**.
+2. Em uma proposta, seleciona a ação **Criar catálogo (Beta)**.
+3. O sistema abre a página **Catálogo da Proposta**.
+4. Os dados da empresa, do órgão e os itens disponíveis são carregados a partir da proposta.
+5. O usuário personaliza o documento, administra os itens e pode selecionar imagens.
+6. O usuário pode salvar a configuração ou gerar a visualização do catálogo.
+7. Na visualização gerada, é possível imprimir, fechar ou habilitar uma edição visual temporária.
+
+## Layout da página de edição
+
+A página é organizada verticalmente, em formato de formulário documental. No desktop observado, o conteúdo ocupa uma coluna central e os itens aparecem como cartões empilhados.
+
+### Cabeçalho da empresa
+
+O topo apresenta um cartão com:
+
+- logotipo da plataforma/empresa;
+- razão social ou nome da empresa;
+- endereço;
+- CNPJ;
+- telefone;
+- e-mail.
+
+Não foram observados campos para editar esses dados diretamente na página. Eles aparentam vir do cadastro da empresa vinculada à proposta.
+
+### Personalização
+
+O primeiro bloco editável contém:
+
+| Campo | Comportamento observado |
+|---|---|
+| Título do catálogo | Campo de texto, preenchido inicialmente com `Catálogo de Produtos`; aparece no topo do documento gerado |
+| Subtítulo | Campo de texto opcional |
+| Observações gerais | Área de texto opcional, exibida depois da lista de produtos |
+
+O campo de título possui o texto auxiliar **Exibido no topo do catálogo**. As observações possuem o texto auxiliar **Texto exibido após a lista de produtos. Opcional.**
+
+### Dados do órgão
+
+O bloco **Dados do Órgão** apresenta os seguintes campos:
+
+- Órgão;
+- Estado;
+- Número da Compra;
+- Número do Processo;
+- Data de Recebimento;
+- Data de Abertura.
+
+Os valores são carregados a partir da licitação/proposta. Na página avaliada, esses dados estavam disponíveis no formulário e também foram reproduzidos na visualização final.
+
+### Itens do catálogo
+
+A seção **Itens do Catálogo** possui o botão **Adicionar item** e uma lista de cartões numerados como **Item 1**, **Item 2** e assim sucessivamente.
+
+Cada item possui:
+
+- ação para mover para cima;
+- ação para mover para baixo;
+- ação **Remover item**;
+- área de imagem;
+- ação **Selecionar imagem**;
+- ação **Remover imagem**;
+- Título do produto;
+- Especificações;
+- Quantidade;
+- Unidade;
+- Marca.
+
+O primeiro item foi preenchido automaticamente com os dados do item da proposta: descrição/título, especificação, quantidade, unidade e marca. Quando não existe imagem, a área apresenta **Sem imagem**.
+
+Não foram observados campos de preço no catálogo. O documento tem finalidade descritiva/comercial, centrada na apresentação dos produtos ou serviços.
+
+## Administração dos itens
+
+### Adicionar item
+
+Ao selecionar **Adicionar item**, um novo cartão é inserido na lista sem recarregar a página. O novo item contém os mesmos campos e controles, mas começa sem título, especificações, quantidade, unidade, marca ou imagem.
+
+Isso permite complementar o catálogo com um produto que não estava originalmente na proposta.
+
+### Ordenar itens
+
+Os botões com setas para cima e para baixo indicam que o usuário pode definir manualmente a ordem dos produtos. A ordem apresentada no formulário deve ser preservada na visualização e impressão.
+
+Os limites precisam ser respeitados na implementação: o primeiro item não deve subir além da primeira posição e o último não deve descer além da última posição.
+
+### Remover e desfazer remoção
+
+Ao selecionar **Remover item**, o cartão não desaparece imediatamente. Ele permanece na página e a ação muda para **Desfazer remoção**.
+
+Portanto, a remoção é reversível enquanto o formulário ainda não foi salvo. Esse comportamento evita exclusões acidentais e sugere que o item é marcado localmente como removido antes da persistência.
+
+Não foi efetuado o salvamento de um item marcado para remoção; assim, não foi possível confirmar se a exclusão persistida é lógica ou física.
+
+### Imagem do item
+
+Cada item aceita uma imagem independente. Foram identificadas as ações para selecionar e remover a imagem, além do estado vazio **Sem imagem**.
+
+O seletor não foi aberto e nenhum arquivo foi enviado. Permanecem não confirmados:
+
+- origem da imagem, como upload local ou biblioteca de mídia;
+- formatos aceitos;
+- limite de tamanho;
+- recorte ou redimensionamento;
+- dimensões recomendadas;
+- momento do upload, imediato ou somente ao salvar;
+- regras de armazenamento e exclusão.
+
+## Ações do formulário
+
+No final da página existem duas ações principais:
+
+### Salvar catálogo
+
+A ação **Salvar catálogo** aparenta persistir a personalização, os dados do órgão, os itens, sua ordem, imagens e itens marcados para remoção.
+
+O salvamento não foi executado para não alterar dados no sistema de referência. Portanto, mensagens de sucesso, validações, obrigatoriedade dos campos e comportamento de criação/atualização ainda precisam ser definidos no Licitador.
+
+### Gerar catálogo
+
+A ação **Gerar catálogo** abre uma visualização separada do catálogo já existente. A URL da visualização usa o identificador próprio do catálogo e não o identificador da proposta.
+
+No fluxo analisado, a visualização foi aberta em outra aba. Não foi possível confirmar se, para um catálogo novo ou alterado, é obrigatório salvar antes de gerar.
+
+## Visualização gerada
+
+A visualização possui aparência de documento pronto para impressão, com fundo claro e conteúdo organizado em uma única página no exemplo avaliado.
+
+### Cabeçalho
+
+Apresenta:
+
+- título do catálogo em destaque;
+- logotipo;
+- dados cadastrais e de contato da empresa.
+
+### Dados do órgão
+
+O bloco **Dados do Órgão** reproduz os seis dados cadastrados no formulário de edição.
+
+### Produtos
+
+Cada produto é exibido em um cartão contendo:
+
+- imagem ou o texto **Imagem não disponível**;
+- título;
+- especificações;
+- quantidade;
+- unidade;
+- marca.
+
+As observações gerais devem aparecer após a lista de produtos, conforme o texto auxiliar do formulário. A proposta avaliada não possuía observação preenchida, portanto esse conteúdo não apareceu na visualização.
+
+### Ações da visualização
+
+No canto superior direito existem três ações:
+
+- **Imprimir catálogo**;
+- **Fechar**;
+- **Habilitar edição**.
+
+Esses controles fazem parte da interface de visualização e não do conteúdo comercial que deve ser impresso.
+
+## Edição na visualização
+
+Ao selecionar **Habilitar edição**:
+
+- o botão muda para **Desabilitar edição**;
+- contornos azuis tracejados aparecem sobre diversas regiões textuais;
+- os blocos da empresa, órgão e produtos passam a indicar visualmente que seu conteúdo pode ser alterado;
+- título, dados do órgão, título e especificações do produto, quantidade, unidade e marca foram identificados como regiões editáveis.
+
+Ao selecionar **Desabilitar edição**, os contornos desaparecem e o documento volta ao modo normal de visualização.
+
+Não apareceu uma ação de salvar dentro da visualização. Assim, o comportamento mais provável é uma edição local, destinada a ajustes pontuais antes da impressão. Isso é uma **inferência visual**, não uma regra confirmada: não foram alterados textos nem recarregada a página para testar persistência.
+
+Para o Licitador, é necessário decidir explicitamente se essas alterações:
+
+- existem apenas no navegador e na impressão atual; ou
+- devem ser enviadas e persistidas no catálogo.
+
+Se o objetivo for reproduzir fielmente o comportamento aparente, a edição da visualização deve ser temporária e não deve substituir o formulário principal de edição.
+
+## Impressão
+
+A ação **Imprimir catálogo** abre a pré-visualização nativa de impressão do navegador.
+
+No teste foram observados:
+
+- documento de uma página para o catálogo avaliado;
+- seleção de destino, incluindo salvar como PDF;
+- seleção de páginas;
+- quantidade de páginas por folha;
+- configuração de margens;
+- opção de cabeçalhos e rodapés;
+- opção de gráficos de segundo plano;
+- botões do navegador para salvar/imprimir ou cancelar.
+
+A impressão foi cancelada. Nenhum PDF foi salvo e nenhuma impressão foi enviada.
+
+O layout de impressão preservou o cabeçalho da empresa, os dados do órgão e o cartão do produto. As ações da interface não apareceram dentro do documento.
+
+## Regras funcionais identificadas
+
+- Um catálogo nasce no contexto de uma proposta.
+- A proposta fornece os dados iniciais da empresa, do órgão e dos itens.
+- O catálogo possui identificador e ciclo de vida próprios.
+- Um catálogo pode conter itens originados da proposta e itens adicionados manualmente.
+- Os dados copiados precisam ser editáveis no catálogo sem alterar a proposta de origem.
+- Cada item tem conteúdo, imagem e posição próprios.
+- A ordem dos itens é controlada pelo usuário.
+- A remoção pode ser desfeita antes de salvar.
+- A visualização deve manter a ordem e o conteúdo definidos no formulário.
+- A ausência de imagem possui um estado visual explícito.
+- A versão gerada é preparada para impressão e PDF.
+- A visualização oferece um modo de edição pontual que precisa ser tratado separadamente da edição persistente.
+
+## Dados implementados no backend
+
+### Catálogo
+
+- empresa proprietária;
+- proposta de origem;
+- título;
+- subtítulo opcional;
+- observações gerais opcionais;
+- órgão;
+- estado;
+- número da compra;
+- número do processo;
+- data de recebimento;
+- data de abertura;
+- usuário criador;
+- usuário responsável pela última alteração;
+- datas de criação e atualização.
+
+Os dados da empresa e do órgão são armazenados como uma cópia no catálogo. Dessa forma, alterações futuras na proposta, licitação ou empresa não modificam silenciosamente o documento comercial já preparado.
+
+### Item do catálogo
+
+- catálogo;
+- item da proposta de origem, opcional para itens adicionados manualmente;
+- título;
+- especificações;
+- quantidade;
+- unidade;
+- marca;
+- referência da imagem, opcional;
+- posição de ordenação;
+- datas de criação e atualização.
+
+### Imagem
+
+As imagens são armazenadas no disco público configurado pelo Laravel, em `proposal-catalogs/{catalog_id}`. A API retorna `image_url` e não expõe `image_path`.
+
+São aceitos arquivos JPG, JPEG, PNG e WEBP de até 5 MB. Ao substituir ou remover uma imagem, o arquivo anterior também é excluído do armazenamento.
+
+## Comportamento esperado no Licitador
+
+### Criação
+
+- A ação deve existir em uma proposta que pertença à empresa autenticada.
+- Na primeira abertura, a API deve criar ou preparar um rascunho com os dados da proposta.
+- A criação não deve alterar a proposta nem seus itens.
+- Cada proposta possui no máximo um catálogo. A primeira consulta cria o catálogo e as consultas seguintes retornam o mesmo registro.
+
+### Edição persistente
+
+O usuário deve poder:
+
+- alterar título, subtítulo e observações;
+- ajustar os dados do órgão no catálogo;
+- editar os dados copiados dos itens;
+- adicionar item manual;
+- reordenar itens;
+- marcar item para remoção e desfazer antes de salvar;
+- selecionar, trocar e remover imagem;
+- salvar e retomar o catálogo posteriormente.
+
+### Visualização
+
+- Deve existir uma rota ou endpoint de leitura pelo identificador do catálogo.
+- A visualização precisa respeitar as mesmas permissões do catálogo.
+- O layout deve ser próprio para impressão, com quebra de páginas previsível quando houver vários itens.
+- Os controles de tela devem ser ocultados via estilo de impressão.
+- O estado **Imagem não disponível** deve ser apresentado quando aplicável.
+
+### Segurança e permissões
+
+- A API não deve confiar apenas nos identificadores recebidos na URL.
+- Somente usuários autorizados da empresa proprietária podem criar, consultar, alterar, imprimir ou excluir o catálogo.
+- A proposta de origem deve ser validada no escopo da empresa autenticada.
+- Uploads precisam de validação e armazenamento privado ou exposição controlada conforme a política do projeto.
+
+## Contrato implementado no backend
+
+Todos os endpoints exigem a autenticação JWT e o usuário ativo já utilizados nas rotas protegidas da API.
+
+```text
+GET    /api/proposal/{proposal_id}/catalog
+PUT    /api/proposal/{proposal_id}/catalog
+POST   /api/proposal/{proposal_id}/catalog/generate
+POST   /api/proposal/{proposal_id}/catalog/items/{item_id}/image
+DELETE /api/proposal/{proposal_id}/catalog/items/{item_id}/image
+GET    /api/proposal-catalog/{catalog_id}/view
+```
+
+Não existe endpoint de exclusão do catálogo inteiro nem endpoints individuais para criar ou editar itens. O formulário é salvo como uma unidade transacional por meio do `PUT`.
+
+### Envelope das respostas
+
+As respostas JSON seguem o padrão:
+
+```json
+{
+  "status": true,
+  "message": null,
+  "data": {},
+  "error": null
+}
+```
+
+Erros de validação retornam HTTP `400`; proposta, catálogo ou item fora do escopo do usuário retornam `404`. O backend valida tanto a propriedade da proposta quanto o pertencimento dos itens enviados.
+
+### Abrir ou inicializar o catálogo
+
+```http
+GET /api/proposal/{proposal_id}/catalog
+```
+
+Na primeira chamada, o backend cria automaticamente o catálogo, copia o snapshot atual da empresa, os dados do órgão e todos os itens da proposta. Nas chamadas seguintes, retorna o mesmo catálogo sem duplicar registros nem recarregar os dados da proposta.
+
+Formato relevante de `data`:
+
+```json
+{
+  "id": 10,
+  "proposal_id": 35,
+  "user_id": 7,
+  "company_id": 4,
+  "title": "Catálogo de Produtos",
+  "subtitle": null,
+  "general_notes": null,
+  "organ_name": "Órgão de exemplo",
+  "organ_state": "MG",
+  "purchase_number": "001/2026",
+  "process_number": "PROC-1",
+  "receipt_date": null,
+  "opening_date": null,
+  "company_snapshot": {
+    "corporate_reason": "Empresa de exemplo",
+    "cnpj": "...",
+    "logo": null
+  },
+  "last_updated_by": 7,
+  "generated_at": null,
+  "items": [
+    {
+      "id": 50,
+      "proposal_catalog_id": 10,
+      "proposal_item_id": 80,
+      "title": "Produto de exemplo",
+      "specification": "Descrição completa",
+      "quantity": "2.0000",
+      "unit": "UN",
+      "brand": "Marca A",
+      "position": 1,
+      "image_original_name": null,
+      "image_mime": null,
+      "image_url": null
+    }
+  ],
+  "proposal": {},
+  "company": {}
+}
+```
+
+Campos de data podem ser serializados em ISO 8601 pelo Laravel. O frontend deve formatá-los para exibição e enviar datas editadas no formato `YYYY-MM-DD`.
+
+### Salvar o catálogo
+
+```http
+PUT /api/proposal/{proposal_id}/catalog
+Content-Type: application/json
+```
+
+Exemplo:
+
+```json
+{
+  "title": "Catálogo de Produtos",
+  "subtitle": "Linha profissional 2026",
+  "general_notes": "Condições e observações gerais.",
+  "organ_name": "Órgão de exemplo",
+  "organ_state": "MG",
+  "purchase_number": "001/2026",
+  "process_number": "PROC-1",
+  "receipt_date": "2026-07-20",
+  "opening_date": "2026-07-21",
+  "items": [
+    {
+      "id": 50,
+      "proposal_item_id": 80,
+      "title": "Produto editado",
+      "specification": "Descrição completa",
+      "quantity": 2,
+      "unit": "UN",
+      "brand": "Marca A",
+      "position": 1
+    },
+    {
+      "title": "Item adicionado manualmente",
+      "specification": "Não possui item de proposta como origem",
+      "quantity": 1,
+      "unit": "UN",
+      "brand": "Marca B",
+      "position": 2
+    }
+  ]
+}
+```
+
+Regras importantes:
+
+- metadados são parciais: campos não enviados permanecem como estão;
+- quando `items` não é enviado, os itens atuais permanecem inalterados;
+- quando `items` é enviado, ele representa a lista final completa;
+- item existente deve enviar `id`;
+- item originado da proposta deve manter `proposal_item_id`;
+- o vínculo `proposal_item_id` de um item já existente é imutável; para trocar a origem, remova o item e crie outro;
+- item manual não envia `id` nem `proposal_item_id` na primeira gravação;
+- item existente omitido da lista é removido do catálogo;
+- a remoção/desfazer antes de salvar é um estado local do frontend;
+- `position` não pode se repetir; o backend ordena a lista recebida e normaliza as posições para `1..N`;
+- as imagens dos itens mantidos são preservadas, mesmo não aparecendo no JSON do `PUT`;
+- imagens de itens removidos também são apagadas do armazenamento;
+- qualquer salvamento limpa `generated_at`, indicando que o catálogo precisa ser gerado novamente;
+- o retorno contém o catálogo completo e os IDs definitivos dos itens novos.
+
+### Enviar, substituir ou remover imagem
+
+Um item manual precisa primeiro ser salvo pelo `PUT`, para que receba um `id`. Depois, a imagem pode ser enviada:
+
+```http
+POST /api/proposal/{proposal_id}/catalog/items/{item_id}/image
+Content-Type: multipart/form-data
+
+image=<arquivo>
+```
+
+Formatos aceitos: JPG, JPEG, PNG e WEBP. Tamanho máximo: 5 MB. O campo multipart deve se chamar `image`.
+
+O mesmo endpoint substitui uma imagem existente e remove o arquivo anterior. Para remover sem substituir:
+
+```http
+DELETE /api/proposal/{proposal_id}/catalog/items/{item_id}/image
+```
+
+As duas operações retornam o item atualizado e limpam `generated_at` do catálogo.
+
+### Gerar e visualizar
+
+```http
+POST /api/proposal/{proposal_id}/catalog/generate
+```
+
+Marca o instante atual em `generated_at` e retorna o catálogo completo. O backend não gera HTML nem PDF: a página documental, a edição temporária e a impressão são responsabilidades do frontend.
+
+Para carregar a visualização pelo identificador próprio do catálogo:
+
+```http
+GET /api/proposal-catalog/{catalog_id}/view
+```
+
+Essa rota continua autenticada e devolve o mesmo payload completo. Não existe compartilhamento público nesta implementação.
+
+## Decisões implementadas
+
+- cardinalidade de um catálogo por proposta;
+- snapshot da empresa e dos dados do órgão;
+- cópia inicial dos itens, sem sincronização automática posterior;
+- itens adicionais manuais;
+- atualização transacional da lista completa;
+- posições únicas e normalizadas;
+- exclusão de itens omitidos no salvamento;
+- imagens públicas controladas por endpoints autenticados de escrita;
+- formatos JPG, JPEG, PNG e WEBP, com limite de 5 MB;
+- substituição e remoção do arquivo físico anterior;
+- visualização autenticada;
+- geração representada por `generated_at`;
+- edição visual temporária, impressão e PDF deixados para o navegador/frontend.
+
+## Pontos não confirmados no sistema de referência
+
+Por segurança, nenhuma alteração foi persistida no sistema usado como referência. Continuam sem confirmação externa:
+
+- limites originais de caracteres e imagens;
+- persistência do modo **Habilitar edição**;
+- quebra de página com muitos produtos;
+- possibilidade de vários catálogos por proposta;
+- existência de exclusão completa ou compartilhamento público.
+
+As decisões do Licitador para esses pontos estão descritas no contrato acima e têm precedência durante a implementação do frontend.
+
+## Validação do backend
+
+- migration `2026_07_15_000004_create_proposal_catalogs_tables` aplicada com sucesso no MySQL;
+- constraints possuem nomes explícitos compatíveis com o limite de identificadores do MySQL;
+- suíte automatizada: 26 testes aprovados e 129 asserções;
+- cobertura específica para inicialização idempotente, snapshot, itens, ordenação, remoção, segurança, imagens, geração e visualização.
+
+## Prompt para o agente do frontend
+
+```text
+Implemente no frontend do Licitador a funcionalidade “Criar catálogo (Beta)” usando como especificação integral o arquivo docs/catalogo-de-propostas.md do backend.
+
+Objetivo:
+- adicionar/usar a ação “Criar catálogo (Beta)” na listagem de propostas;
+- construir a tela de edição do catálogo;
+- construir a visualização documental preparada para impressão/PDF;
+- reproduzir o layout e os comportamentos mapeados no documento;
+- não alterar o backend nem inventar campos ou endpoints diferentes do contrato.
+
+API autenticada disponível:
+- GET /api/proposal/{proposal_id}/catalog: abre e inicializa uma única vez o catálogo;
+- PUT /api/proposal/{proposal_id}/catalog: salva metadados e, quando enviado, substitui transacionalmente a lista completa de itens;
+- POST /api/proposal/{proposal_id}/catalog/items/{item_id}/image: multipart/form-data com campo image;
+- DELETE /api/proposal/{proposal_id}/catalog/items/{item_id}/image: remove a imagem;
+- POST /api/proposal/{proposal_id}/catalog/generate: marca a geração e retorna o payload completo;
+- GET /api/proposal-catalog/{catalog_id}/view: carrega a visualização autenticada.
+
+Tela de edição:
+- cabeçalho com logo e snapshot da empresa;
+- campos título, subtítulo e observações gerais;
+- campos órgão, estado, número da compra, número do processo, data de recebimento e data de abertura;
+- seção “Itens do Catálogo” em cartões ordenados;
+- cada item tem imagem, título, especificações, quantidade, unidade e marca;
+- ações adicionar item, mover para cima, mover para baixo, remover item e desfazer remoção;
+- ao remover, mantenha o cartão marcado localmente e ofereça “Desfazer remoção”; só retire o item do array enviado ao salvar;
+- preserve IDs de itens existentes e proposal_item_id dos itens originados da proposta;
+- itens manuais novos não têm id nem proposal_item_id até o primeiro PUT;
+- envie positions únicas seguindo a ordem visual;
+- implemente estados de carregamento, erro, vazio, salvando e sucesso sem bloquear a edição desnecessariamente.
+
+Imagens:
+- permita selecionar JPG, JPEG, PNG ou WEBP de até 5 MB;
+- mostre preview local imediatamente;
+- para item novo, primeiro salve o catálogo, leia o id retornado e depois envie o arquivo;
+- para item já persistido, use o endpoint multipart de imagem;
+- ao substituir ou remover, atualize a UI com o item retornado;
+- use image_url para exibir e “Sem imagem”/“Imagem não disponível” quando for null.
+
+Salvar e gerar:
+- “Salvar catálogo” chama PUT com a lista final completa de itens;
+- se items for omitido, o backend não altera a lista; se for enviado, itens omitidos são excluídos;
+- depois do PUT, substitua o estado local pelo payload retornado para capturar IDs e posições normalizadas;
+- uploads pendentes de itens novos devem ocorrer somente após esse retorno;
+- “Gerar catálogo” deve garantir que alterações e imagens pendentes foram salvas e então chamar POST generate;
+- abra/navegue para a visualização usando o catalog_id retornado.
+
+Visualização:
+- documento com título/subtítulo, empresa, dados do órgão, cartões de produtos e observações ao final;
+- mostrar imagem ou placeholder, título, especificações, quantidade, unidade e marca;
+- ações “Imprimir catálogo”, “Fechar” e “Habilitar edição”;
+- “Habilitar edição” deve permitir ajustes temporários no DOM, com contornos tracejados, sem persistir no backend;
+- alternar o texto para “Desabilitar edição” quando ativo;
+- imprimir com window.print();
+- criar CSS @media print que esconda ações/controles, preserve cores e imagens e trate quebras de página entre cartões;
+- não implementar geração de PDF no servidor.
+
+Integração e qualidade:
+- seguir os padrões atuais do projeto para rotas, serviços HTTP, componentes, formulários, notificações e estilos;
+- respeitar autenticação e o envelope { status, message, data, error };
+- formatar datas ISO recebidas e enviar datas como YYYY-MM-DD;
+- tratar HTTP 400 como validação e HTTP 404 como recurso sem acesso/inexistente;
+- manter o layout responsivo, principalmente ações dos cartões e rodapé, sem overflow horizontal;
+- não expor image_path; usar somente image_url;
+- adicionar testes proporcionais aos padrões existentes e executar lint/build/testes ao final;
+- documentar no frontend os arquivos criados, decisões de UI e comandos de validação executados.
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,5 @@
 <?php
 
-use App\Http\Middleware\UserStatusMiddleware;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AutomationController;
 use App\Http\Controllers\CategoryController;
@@ -10,12 +7,16 @@ use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\FileController;
 use App\Http\Controllers\FilterController;
+use App\Http\Controllers\ProposalCatalogController;
 use App\Http\Controllers\ProposalController;
+use App\Http\Controllers\ProposalTrackingController;
 use App\Http\Controllers\SettingController;
 use App\Http\Controllers\TenderController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\WebhookController;
 use App\Http\Middleware\AdminMiddleware;
+use App\Http\Middleware\UserStatusMiddleware;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -43,15 +44,15 @@ Route::get('validateToken', [AuthController::class, 'validateToken']);
 //     });
 // });
 
-Route::middleware(['jwt', UserStatusMiddleware::class])->group(function(){
+Route::middleware(['jwt', UserStatusMiddleware::class])->group(function () {
     Route::post('logout', [AuthController::class, 'logout']);
 
-    Route::prefix('tender')->group(function(){
+    Route::prefix('tender')->group(function () {
         Route::get('search', [TenderController::class, 'search']);
         Route::get('get-edital/{idLicitacao}', [TenderController::class, 'edital']);
         Route::get('{tender_id}/items', [TenderController::class, 'items']);
         Route::post('note', [TenderController::class, 'note']);
-        Route::post('favorite/{tender_id}', [TenderController::class, 'favorite']);        
+        Route::post('favorite/{tender_id}', [TenderController::class, 'favorite']);
         Route::get('calendar', [TenderController::class, 'calendar']);
         Route::post('calendar/{tender_id}', [TenderController::class, 'calendarToggle']);
         Route::delete('note-delete/{note_id}', [TenderController::class, 'noteDelete']);
@@ -59,23 +60,23 @@ Route::middleware(['jwt', UserStatusMiddleware::class])->group(function(){
     });
 
     // Open user
-    Route::prefix('user')->group(function(){
+    Route::prefix('user')->group(function () {
         Route::get('getUser', [UserController::class, 'getUser']);
         Route::patch('{id}', [UserController::class, 'update']);
         Route::get('/login-as/{userId}', [UserController::class, 'loginAsUser']);
     });
 
-    Route::prefix('filter')->group(function(){
+    Route::prefix('filter')->group(function () {
         Route::get('/', [FilterController::class, 'getFilter']);
         Route::post('/', [FilterController::class, 'createOrUpdate']);
     });
 
-    Route::prefix('company')->group(function(){
+    Route::prefix('company')->group(function () {
         Route::get('/', [CompanyController::class, 'getCompany']);
         Route::post('/', [CompanyController::class, 'createOrUpdate']);
     });
 
-    Route::prefix('proposal')->group(function(){
+    Route::prefix('proposal')->group(function () {
         Route::get('/', [ProposalController::class, 'search']);
         Route::post('fill', [ProposalController::class, 'fill']);
         Route::post('/', [ProposalController::class, 'create']);
@@ -83,52 +84,65 @@ Route::middleware(['jwt', UserStatusMiddleware::class])->group(function(){
         Route::patch('{id}', [ProposalController::class, 'update']);
         Route::delete('{id}', [ProposalController::class, 'delete']);
         Route::get('{id}/view', [ProposalController::class, 'view']);
+        Route::get('{proposalId}/tracking', [ProposalTrackingController::class, 'get']);
+        Route::put('{proposalId}/tracking', [ProposalTrackingController::class, 'update']);
+        Route::post('{proposalId}/tracking/apply-discount', [ProposalTrackingController::class, 'applyDiscount']);
+        Route::post('{proposalId}/tracking/finish', [ProposalTrackingController::class, 'finish']);
+        Route::post('{proposalId}/tracking/reopen', [ProposalTrackingController::class, 'reopen']);
+        Route::get('{proposalId}/tracking/print', [ProposalTrackingController::class, 'print']);
+        Route::get('{proposalId}/tracking/export', [ProposalTrackingController::class, 'export']);
+        Route::get('{proposalId}/catalog', [ProposalCatalogController::class, 'get']);
+        Route::put('{proposalId}/catalog', [ProposalCatalogController::class, 'update']);
+        Route::post('{proposalId}/catalog/generate', [ProposalCatalogController::class, 'generate']);
+        Route::post('{proposalId}/catalog/items/{itemId}/image', [ProposalCatalogController::class, 'uploadImage']);
+        Route::delete('{proposalId}/catalog/items/{itemId}/image', [ProposalCatalogController::class, 'deleteImage']);
     });
 
-    Route::prefix('file')->group(function(){
+    Route::get('proposal-catalog/{catalogId}/view', [ProposalCatalogController::class, 'view']);
+
+    Route::prefix('file')->group(function () {
         Route::get('search', [FileController::class, 'search']);
         Route::post('create', [FileController::class, 'create']);
         Route::patch('{id}', [FileController::class, 'update']);
         Route::delete('{id}', [FileController::class, 'delete']);
     });
 
-    Route::prefix('category')->group(function(){
+    Route::prefix('category')->group(function () {
         Route::get('search', [CategoryController::class, 'search']);
         Route::get('all', [CategoryController::class, 'all']);
     });
 
     Route::get('setting/search', [SettingController::class, 'search']);
 
-    Route::middleware(AdminMiddleware::class)->group(function(){
-        Route::prefix('user')->group(function(){
+    Route::middleware(AdminMiddleware::class)->group(function () {
+        Route::prefix('user')->group(function () {
             Route::get('search', [UserController::class, 'search']);
             Route::post('create', [UserController::class, 'create']);
             Route::post('block/{id}', [UserController::class, 'userBlock']);
             Route::delete('{id}', [UserController::class, 'delete']);
         });
 
-        Route::prefix('category')->group(function(){
+        Route::prefix('category')->group(function () {
             Route::post('create', [CategoryController::class, 'create']);
             Route::patch('{id}', [CategoryController::class, 'update']);
             Route::delete('{id}', [CategoryController::class, 'delete']);
         });
 
-        Route::prefix('dashboard')->group(function(){
+        Route::prefix('dashboard')->group(function () {
             Route::get('search', [DashboardController::class, 'search']);
             Route::get('indicators', [DashboardController::class, 'indicators']);
             Route::get('userGraph', [DashboardController::class, 'userGraph']);
         });
 
-        Route::prefix('automation')->group(function(){
+        Route::prefix('automation')->group(function () {
             Route::get('search', [AutomationController::class, 'search']);
             Route::post('create', [AutomationController::class, 'create']);
         });
 
         Route::patch('setting/update', [SettingController::class, 'update']);
     });
-});    
+});
 
-
-Route::prefix('webhook')->group(function() {
+Route::prefix('webhook')->group(function () {
     Route::post('hotmart', [WebhookController::class, 'handle']);
 });

--- a/tests/Feature/ProposalTest.php
+++ b/tests/Feature/ProposalTest.php
@@ -9,7 +9,9 @@ use App\Models\User;
 use App\Services\Tender\TenderService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 use Mockery;
 use Tests\TestCase;
 
@@ -154,6 +156,488 @@ class ProposalTest extends TestCase
             ->assertJsonCount(1, 'data.items');
     }
 
+    public function test_tracking_is_initialized_with_pending_items(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $proposal->items()->create([
+            'item' => '1',
+            'quantity' => 2,
+            'unit_price' => 10,
+            'total_value' => 20,
+        ]);
+
+        $response = $this->actingAs($user)->getJson("/api/proposal/{$proposal->id}/tracking");
+
+        $response->assertOk()
+            ->assertJsonPath('status', true)
+            ->assertJsonPath('data.tracking.status', 'open')
+            ->assertJsonPath('data.items.0.result', 'pending')
+            ->assertJsonPath('data.items.0.minimum_unit_price', null)
+            ->assertJsonPath('data.totals.original', '0.00')
+            ->assertJsonPath('data.totals.minimum', '0.00');
+
+        $this->assertDatabaseCount('proposal_trackings', 1);
+        $this->assertDatabaseCount('proposal_tracking_items', 1);
+    }
+
+    public function test_tracking_applies_non_cumulative_discount_to_all_items(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $proposal->update(['total_value' => 20]);
+        $proposal->items()->create([
+            'item' => '1',
+            'quantity' => 2,
+            'unit_price' => 10,
+            'total_value' => 20,
+        ]);
+
+        $this->actingAs($user)->postJson("/api/proposal/{$proposal->id}/tracking/apply-discount", [
+            'discount_percentage' => 10,
+        ])->assertOk()
+            ->assertJsonPath('data.items.0.minimum_unit_price', '9.0000')
+            ->assertJsonPath('data.items.0.minimum_total_value', '18.00');
+
+        $this->actingAs($user)->postJson("/api/proposal/{$proposal->id}/tracking/apply-discount", [
+            'discount_percentage' => 20,
+        ])->assertOk()
+            ->assertJsonPath('data.items.0.minimum_unit_price', '8.0000')
+            ->assertJsonPath('data.items.0.minimum_total_value', '16.00');
+    }
+
+    public function test_tracking_updates_results_prices_classification_and_won_total(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $wonItem = $proposal->items()->create([
+            'item' => '1',
+            'quantity' => 2,
+            'unit_price' => 10,
+            'total_value' => 20,
+        ]);
+        $lostItem = $proposal->items()->create([
+            'item' => '2',
+            'quantity' => 3,
+            'unit_price' => 5,
+            'total_value' => 15,
+        ]);
+        $proposal->update(['total_value' => 35]);
+
+        $response = $this->actingAs($user)->putJson("/api/proposal/{$proposal->id}/tracking", [
+            'items' => [
+                [
+                    'proposal_item_id' => $wonItem->id,
+                    'result' => 'won',
+                    'minimum_unit_price' => 9,
+                    'rankings' => [
+                        [
+                            'position' => 1,
+                            'company' => 'Empresa Teste LTDA',
+                            'brand' => 'Marca A',
+                            'price' => 9,
+                        ],
+                        [
+                            'position' => 2,
+                            'company' => 'Concorrente A',
+                            'brand' => 'Marca B',
+                            'price' => 9.5,
+                        ],
+                    ],
+                ],
+                [
+                    'proposal_item_id' => $lostItem->id,
+                    'result' => 'lost',
+                    'minimum_unit_price' => 4.5,
+                    'rankings' => [
+                        [
+                            'position' => 1,
+                            'company' => 'Concorrente B',
+                            'brand' => 'Marca C',
+                            'price' => 4,
+                        ],
+                        [
+                            'position' => 3,
+                            'company' => 'Empresa Teste LTDA',
+                            'brand' => 'Marca A',
+                            'price' => 5,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.items.0.result', 'won')
+            ->assertJsonPath('data.items.1.result', 'lost')
+            ->assertJsonPath('data.items.0.rankings.0.position', 1)
+            ->assertJsonPath('data.items.0.rankings.0.company', 'Empresa Teste LTDA')
+            ->assertJsonPath('data.items.1.rankings.1.position', 3)
+            ->assertJsonPath('data.items.1.rankings.1.price', '5.0000')
+            ->assertJsonPath('data.totals.minimum', '31.50')
+            ->assertJsonPath('data.totals.won', '18.00')
+            ->assertJsonCount(1, 'data.won_items');
+
+        $this->assertDatabaseCount('proposal_tracking_item_rankings', 4);
+
+        $this->actingAs($user)
+            ->putJson("/api/proposal/{$proposal->id}/tracking", [
+                'items' => [[
+                    'proposal_item_id' => $wonItem->id,
+                    'result' => 'pending',
+                ]],
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.items.0.result', 'pending')
+            ->assertJsonCount(0, 'data.items.0.rankings');
+
+        $this->assertDatabaseCount('proposal_tracking_item_rankings', 2);
+    }
+
+    public function test_finished_tracking_is_read_only_until_reopened(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $item = $proposal->items()->create(['item' => '1', 'quantity' => 1, 'unit_price' => 10]);
+
+        $this->actingAs($user)
+            ->postJson("/api/proposal/{$proposal->id}/tracking/finish")
+            ->assertOk()
+            ->assertJsonPath('data.tracking.status', 'finished');
+
+        $this->actingAs($user)
+            ->putJson("/api/proposal/{$proposal->id}/tracking", [
+                'items' => [[
+                    'proposal_item_id' => $item->id,
+                    'result' => 'won',
+                    'rankings' => [[
+                        'position' => 1,
+                        'company' => 'Empresa Teste LTDA',
+                        'brand' => 'Marca',
+                        'price' => 10,
+                    ]],
+                ]],
+            ])
+            ->assertStatus(409);
+
+        $this->actingAs($user)
+            ->postJson("/api/proposal/{$proposal->id}/tracking/reopen")
+            ->assertOk()
+            ->assertJsonPath('data.tracking.status', 'open');
+
+        $this->actingAs($user)
+            ->putJson("/api/proposal/{$proposal->id}/tracking", [
+                'items' => [[
+                    'proposal_item_id' => $item->id,
+                    'result' => 'won',
+                    'rankings' => [[
+                        'position' => 1,
+                        'company' => 'Empresa Teste LTDA',
+                        'brand' => 'Marca',
+                        'price' => 10,
+                    ]],
+                ]],
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.items.0.result', 'won');
+    }
+
+    public function test_user_cannot_access_another_user_tracking(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $other = $this->createUser('other@example.com');
+        $company = $this->createCompany($owner);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($owner, $company, $tender);
+
+        $this->actingAs($other)
+            ->getJson("/api/proposal/{$proposal->id}/tracking")
+            ->assertStatus(404);
+    }
+
+    public function test_tracking_rejects_an_item_from_another_proposal(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $otherProposal = $this->createProposal($user, $company, $tender);
+        $otherItem = $otherProposal->items()->create([
+            'item' => 'outro',
+            'quantity' => 1,
+            'unit_price' => 10,
+        ]);
+
+        $this->actingAs($user)
+            ->putJson("/api/proposal/{$proposal->id}/tracking", [
+                'items' => [[
+                    'proposal_item_id' => $otherItem->id,
+                    'result' => 'won',
+                ]],
+            ])
+            ->assertStatus(400)
+            ->assertJsonPath('status', false);
+    }
+
+    public function test_tracking_rejects_duplicate_positions_in_the_same_item(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $item = $proposal->items()->create([
+            'item' => '1',
+            'quantity' => 1,
+            'unit_price' => 10,
+        ]);
+
+        $this->actingAs($user)
+            ->putJson("/api/proposal/{$proposal->id}/tracking", [
+                'items' => [[
+                    'proposal_item_id' => $item->id,
+                    'result' => 'won',
+                    'rankings' => [
+                        ['position' => 1, 'company' => 'Empresa A', 'price' => 10],
+                        ['position' => 1, 'company' => 'Empresa B', 'price' => 11],
+                    ],
+                ]],
+            ])
+            ->assertStatus(400)
+            ->assertJsonPath('status', false);
+
+        $this->assertDatabaseCount('proposal_tracking_item_rankings', 0);
+    }
+
+    public function test_tracking_exposes_print_payload_and_csv_export(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $proposal->items()->create([
+            'item' => '1',
+            'quantity' => 1,
+            'unit_price' => 10,
+            'total_value' => 10,
+        ]);
+
+        $this->actingAs($user)
+            ->getJson("/api/proposal/{$proposal->id}/tracking/print")
+            ->assertOk()
+            ->assertJsonPath('data.document.title', 'Acompanhamento de Licitação');
+
+        $export = $this->actingAs($user)
+            ->get("/api/proposal/{$proposal->id}/tracking/export");
+
+        $export->assertOk()
+            ->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+        $this->assertStringContainsString('Preço unitário mínimo', $export->getContent());
+        $this->assertStringContainsString('Empresa 1º lugar', $export->getContent());
+    }
+
+    public function test_catalog_is_initialized_once_from_the_proposal_snapshot(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $proposal->update(['organ_state' => 'MG', 'purchase_number' => '001/2026']);
+        $proposal->items()->create([
+            'item' => '1',
+            'quantity' => 2,
+            'unit' => 'UN',
+            'specification' => 'Produto teste',
+            'brand' => 'Marca A',
+        ]);
+
+        $first = $this->actingAs($user)->getJson("/api/proposal/{$proposal->id}/catalog");
+        $second = $this->actingAs($user)->getJson("/api/proposal/{$proposal->id}/catalog");
+
+        $first->assertOk()
+            ->assertJsonPath('status', true)
+            ->assertJsonPath('data.title', 'Catálogo de Produtos')
+            ->assertJsonPath('data.organ_state', 'MG')
+            ->assertJsonPath('data.company_snapshot.corporate_reason', 'Empresa Teste LTDA')
+            ->assertJsonPath('data.items.0.title', 'Produto teste')
+            ->assertJsonPath('data.items.0.quantity', '2.0000')
+            ->assertJsonPath('data.items.0.position', 1)
+            ->assertJsonPath('data.items.0.image_url', null);
+
+        $second->assertJsonPath('data.id', $first->json('data.id'));
+        $this->assertDatabaseCount('proposal_catalogs', 1);
+        $this->assertDatabaseCount('proposal_catalog_items', 1);
+    }
+
+    public function test_catalog_update_reorders_adds_and_removes_items_transactionally(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $firstProposalItem = $proposal->items()->create(['item' => '1', 'specification' => 'Remover']);
+        $secondProposalItem = $proposal->items()->create(['item' => '2', 'specification' => 'Manter']);
+
+        $catalog = $this->actingAs($user)->getJson("/api/proposal/{$proposal->id}/catalog")->json('data');
+        $firstItem = collect($catalog['items'])->firstWhere('proposal_item_id', $firstProposalItem->id);
+        $secondItem = collect($catalog['items'])->firstWhere('proposal_item_id', $secondProposalItem->id);
+
+        $response = $this->actingAs($user)->putJson("/api/proposal/{$proposal->id}/catalog", [
+            'title' => 'Catálogo personalizado',
+            'subtitle' => 'Linha 2026',
+            'general_notes' => 'Observação final',
+            'items' => [
+                [
+                    'title' => 'Produto manual',
+                    'specification' => 'Incluído fora da proposta',
+                    'quantity' => 3,
+                    'unit' => 'CX',
+                    'brand' => 'Marca B',
+                    'position' => 1,
+                ],
+                [
+                    'id' => $secondItem['id'],
+                    'proposal_item_id' => $secondProposalItem->id,
+                    'title' => 'Produto mantido e editado',
+                    'position' => 2,
+                ],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Catálogo personalizado')
+            ->assertJsonPath('data.items.0.title', 'Produto manual')
+            ->assertJsonPath('data.items.0.position', 1)
+            ->assertJsonPath('data.items.1.id', $secondItem['id'])
+            ->assertJsonPath('data.items.1.position', 2)
+            ->assertJsonCount(2, 'data.items');
+
+        $this->assertDatabaseMissing('proposal_catalog_items', ['id' => $firstItem['id']]);
+        $this->assertDatabaseHas('proposal_catalog_items', [
+            'proposal_catalog_id' => $catalog['id'],
+            'proposal_item_id' => null,
+            'position' => 1,
+        ]);
+    }
+
+    public function test_catalog_rejects_items_from_another_catalog_or_proposal(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $otherProposal = $this->createProposal($user, $company, $tender);
+        $proposalItem = $proposal->items()->create(['item' => '1']);
+        $otherProposalItem = $otherProposal->items()->create(['item' => '2']);
+
+        $this->actingAs($user)->getJson("/api/proposal/{$proposal->id}/catalog");
+        $otherCatalogItemId = $this->actingAs($user)
+            ->getJson("/api/proposal/{$otherProposal->id}/catalog")
+            ->json('data.items.0.id');
+
+        $this->actingAs($user)->putJson("/api/proposal/{$proposal->id}/catalog", [
+            'items' => [[
+                'id' => $otherCatalogItemId,
+                'proposal_item_id' => $proposalItem->id,
+                'position' => 1,
+            ]],
+        ])->assertStatus(400);
+
+        $catalogItemId = $this->actingAs($user)
+            ->getJson("/api/proposal/{$proposal->id}/catalog")
+            ->json('data.items.0.id');
+
+        $this->actingAs($user)->putJson("/api/proposal/{$proposal->id}/catalog", [
+            'items' => [[
+                'id' => $catalogItemId,
+                'proposal_item_id' => $otherProposalItem->id,
+                'position' => 1,
+            ]],
+        ])->assertStatus(400);
+    }
+
+    public function test_user_cannot_access_another_user_catalog(): void
+    {
+        $owner = $this->createUser('owner-catalog@example.com');
+        $other = $this->createUser('other-catalog@example.com');
+        $company = $this->createCompany($owner);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($owner, $company, $tender);
+        $catalogId = $this->actingAs($owner)
+            ->getJson("/api/proposal/{$proposal->id}/catalog")
+            ->json('data.id');
+
+        $this->actingAs($other)
+            ->getJson("/api/proposal/{$proposal->id}/catalog")
+            ->assertStatus(404);
+        $this->actingAs($other)
+            ->getJson("/api/proposal-catalog/{$catalogId}/view")
+            ->assertStatus(404);
+    }
+
+    public function test_catalog_item_image_can_be_uploaded_replaced_and_removed(): void
+    {
+        Storage::fake('public');
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $proposal->items()->create(['item' => '1', 'specification' => 'Produto']);
+        $itemId = $this->actingAs($user)
+            ->getJson("/api/proposal/{$proposal->id}/catalog")
+            ->json('data.items.0.id');
+
+        $firstUpload = $this->actingAs($user)->postJson(
+            "/api/proposal/{$proposal->id}/catalog/items/{$itemId}/image",
+            ['image' => UploadedFile::fake()->image('produto.png', 400, 300)]
+        );
+        $firstUpload->assertOk()->assertJsonPath('data.image_original_name', 'produto.png');
+        $firstPath = $this->app['db']->table('proposal_catalog_items')->where('id', $itemId)->value('image_path');
+        Storage::disk('public')->assertExists($firstPath);
+
+        $this->actingAs($user)->postJson(
+            "/api/proposal/{$proposal->id}/catalog/items/{$itemId}/image",
+            ['image' => UploadedFile::fake()->image('produto-novo.webp', 400, 300)]
+        )->assertOk();
+        $secondPath = $this->app['db']->table('proposal_catalog_items')->where('id', $itemId)->value('image_path');
+        Storage::disk('public')->assertMissing($firstPath);
+        Storage::disk('public')->assertExists($secondPath);
+
+        $this->actingAs($user)
+            ->deleteJson("/api/proposal/{$proposal->id}/catalog/items/{$itemId}/image")
+            ->assertOk()
+            ->assertJsonPath('data.image_url', null);
+        Storage::disk('public')->assertMissing($secondPath);
+    }
+
+    public function test_catalog_generate_marks_generation_and_view_returns_print_payload(): void
+    {
+        $user = $this->createUser();
+        $company = $this->createCompany($user);
+        $tender = $this->createTender();
+        $proposal = $this->createProposal($user, $company, $tender);
+        $proposal->items()->create(['item' => '1', 'specification' => 'Produto']);
+
+        $generated = $this->actingAs($user)
+            ->postJson("/api/proposal/{$proposal->id}/catalog/generate")
+            ->assertOk();
+        $catalogId = $generated->json('data.id');
+        $this->assertNotNull($generated->json('data.generated_at'));
+
+        $this->actingAs($user)
+            ->getJson("/api/proposal-catalog/{$catalogId}/view")
+            ->assertOk()
+            ->assertJsonPath('data.id', $catalogId)
+            ->assertJsonPath('data.items.0.title', 'Produto');
+    }
+
     private function createSchema(): void
     {
         Schema::create('users', function (Blueprint $table) {
@@ -237,6 +721,73 @@ class ProposalTest extends TestCase
             $table->decimal('unit_price', 15, 4)->nullable();
             $table->decimal('total_value', 15, 2)->nullable();
             $table->json('source_payload')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('proposal_trackings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('proposal_id')->unique();
+            $table->decimal('discount_percentage', 7, 4)->nullable();
+            $table->string('status')->default('open');
+            $table->foreignId('last_updated_by')->nullable();
+            $table->timestamp('finished_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('proposal_tracking_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('proposal_tracking_id');
+            $table->foreignId('proposal_item_id');
+            $table->string('result')->default('pending');
+            $table->decimal('minimum_unit_price', 15, 4)->nullable();
+            $table->timestamp('classified_at')->nullable();
+            $table->foreignId('classified_by')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('proposal_tracking_item_rankings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('proposal_tracking_item_id');
+            $table->unsignedTinyInteger('position');
+            $table->string('company');
+            $table->string('brand')->nullable();
+            $table->decimal('price', 15, 4);
+            $table->timestamps();
+        });
+
+        Schema::create('proposal_catalogs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('proposal_id')->unique();
+            $table->foreignId('user_id');
+            $table->foreignId('company_id')->nullable();
+            $table->string('title')->default('Catálogo de Produtos');
+            $table->string('subtitle')->nullable();
+            $table->longText('general_notes')->nullable();
+            $table->string('organ_name')->nullable();
+            $table->string('organ_state')->nullable();
+            $table->string('purchase_number')->nullable();
+            $table->string('process_number')->nullable();
+            $table->date('receipt_date')->nullable();
+            $table->date('opening_date')->nullable();
+            $table->json('company_snapshot')->nullable();
+            $table->foreignId('last_updated_by')->nullable();
+            $table->timestamp('generated_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('proposal_catalog_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('proposal_catalog_id');
+            $table->foreignId('proposal_item_id')->nullable();
+            $table->string('title')->nullable();
+            $table->longText('specification')->nullable();
+            $table->decimal('quantity', 15, 4)->nullable();
+            $table->string('unit')->nullable();
+            $table->string('brand')->nullable();
+            $table->unsignedInteger('position');
+            $table->string('image_path')->nullable();
+            $table->string('image_original_name')->nullable();
+            $table->string('image_mime', 100)->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Feature/TenderOriginDomainFilterTest.php
+++ b/tests/Feature/TenderOriginDomainFilterTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tender;
+use App\Services\Tender\TenderService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class TenderOriginDomainFilterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->app['db']->purge('sqlite');
+        $this->app['db']->reconnect('sqlite');
+
+        Schema::create('tenders', function (Blueprint $table) {
+            $table->id();
+            $table->string('origin_url')->nullable();
+            $table->dateTime('proposal_closing_date')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('favorite_tenders', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tender_id');
+            $table->unsignedBigInteger('user_id');
+            $table->timestamps();
+        });
+
+        Schema::create('notes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tender_id');
+            $table->unsignedBigInteger('user_id');
+            $table->text('note')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function test_filters_tenders_by_a_list_of_origin_url_prefixes(): void
+    {
+        Tender::create(['origin_url' => 'http://www.varginha.mg.gov.br/licitacao/232323/index.html']);
+        Tender::create(['origin_url' => 'https://pncp.gov.br/app/editais/123']);
+        Tender::create(['origin_url' => 'https://bllcompras.com/process/456']);
+
+        $request = Request::create('/api/tender/search', 'GET', [
+            'origin_domains' => [
+                'http://www.varginha.mg.gov.br',
+                'https://pncp.gov.br',
+            ],
+        ]);
+
+        $result = app(TenderService::class)->search($request);
+
+        $this->assertTrue($result['status']);
+        $this->assertSame(2, $result['data']->total());
+        $this->assertEqualsCanonicalizing(
+            [
+                'http://www.varginha.mg.gov.br/licitacao/232323/index.html',
+                'https://pncp.gov.br/app/editais/123',
+            ],
+            $result['data']->getCollection()->pluck('origin_url')->all()
+        );
+    }
+
+    public function test_accepts_origin_domains_as_a_comma_separated_string(): void
+    {
+        Tender::create(['origin_url' => 'https://comprasbr.com.br/process/123']);
+        Tender::create(['origin_url' => 'https://portal.licitanet.com.br/process/456']);
+
+        $request = Request::create('/api/tender/search', 'GET', [
+            'origin_domains' => 'https://comprasbr.com.br, https://portal.licitanet.com.br',
+        ]);
+
+        $result = app(TenderService::class)->search($request);
+
+        $this->assertTrue($result['status']);
+        $this->assertSame(2, $result['data']->total());
+    }
+}


### PR DESCRIPTION
# feat: adiciona kanban de licitações, acompanhamento e catálogo de propostas

## Resumo

Este PR amplia o módulo de licitações e propostas com:

- suporte a data personalizada e alteração de status nas licitações do calendário;
- estrutura necessária para o kanban de licitações no frontend;
- filtro de licitações por uma lista de domínios de origem;
- acompanhamento completo dos resultados de propostas;
- classificação dos três primeiros colocados por item;
- cálculo de preços mínimos e aplicação de desconto;
- relatório de itens ganhos;
- geração de dados para impressão e exportação CSV;
- criação, edição e visualização de catálogos de propostas;
- ordenação, inclusão, remoção e imagens nos itens do catálogo;
- documentação técnica para implementação do frontend.

Comparação utilizada: `origin/main...HEAD`.

Resumo do diff:

- 26 arquivos alterados;
- 3.525 linhas adicionadas;
- 33 linhas removidas.

## Calendário e kanban de licitações

Foi adicionado o campo `calendar_date` em `calendar_tenders`.

A data:

- pode ser informada ao marcar uma licitação no calendário;
- pode ser alterada posteriormente;
- utiliza `bid_opening_date` como valor inicial quando não for informada;
- pode ser atualizada junto com o status;
- é retornada pela API em formato ISO;
- passa a ser utilizada na ordenação da listagem do calendário.

A API do calendário agora retorna:

```json
{
  "marked": true,
  "calendar_status": "participating",
  "calendar_date": "2026-07-20T13:00:00.000000Z"
}
```

A listagem também passa a expor:

```text
calendar_status
calendar_date
```

Essas informações permitem que o frontend organize as licitações em um kanban por status e altere tanto o status quanto a data.

### Migration

```text
2026_07_15_000001_add_calendar_date_to_calendar_tenders_table.php
```

A migration verifica a existência da coluna antes de criá-la ou removê-la.

## Filtro por domínio de origem

O endpoint de busca de licitações passa a aceitar o filtro:

```text
origin_domains
```

O filtro pode ser enviado como array:

```http
GET /api/tender/search?origin_domains[]=http://www.varginha.mg.gov.br&origin_domains[]=https://pncp.gov.br
```

Ou como string separada por vírgulas:

```http
GET /api/tender/search?origin_domains=http://www.varginha.mg.gov.br,https://pncp.gov.br
```

A comparação é realizada pelo início de `origin_url`.

Exemplo:

```text
Filtro:
http://www.varginha.mg.gov.br

Registro encontrado:
http://www.varginha.mg.gov.br/licitacao/232323/index.html
```

O backend:

- remove espaços desnecessários;
- ignora valores vazios;
- remove valores duplicados;
- escapa caracteres especiais do `LIKE`;
- combina múltiplos domínios utilizando `OR`.

## Acompanhamento de propostas

Foi implementado um módulo completo de acompanhamento para cada proposta.

Cada proposta pode possuir apenas um acompanhamento.

Na primeira consulta, o backend:

- cria o acompanhamento automaticamente;
- cria um item de acompanhamento para cada item da proposta;
- inicializa os itens com resultado `pending`;
- mantém os valores originais da proposta inalterados.

### Estados do acompanhamento

```text
open
finished
```

Quando o acompanhamento está finalizado, alterações são bloqueadas até que ele seja reaberto.

### Estados dos itens

```text
pending
won
lost
```

Os estados são mutuamente exclusivos.

### Preço mínimo

Cada item pode armazenar `minimum_unit_price`.

O valor total mínimo é calculado pelo backend:

```text
minimum_total_value = minimum_unit_price * quantity
```

### Aplicação de desconto

É possível aplicar um percentual de desconto em todos os itens.

```text
minimum_unit_price = original_unit_price * (1 - discount_percentage / 100)
```

O cálculo sempre utiliza o preço original da proposta, evitando descontos cumulativos.

### Classificação dos colocados

Ao marcar um item como vencedor ou perdido, podem ser informadas até três colocações.

Cada posição registra:

```text
position
company
brand
price
```

Exemplo:

```json
{
  "position": 1,
  "company": "Empresa vencedora",
  "brand": "Marca A",
  "price": 1500.00
}
```

Regras:

- posições válidas entre 1 e 3;
- uma posição não pode se repetir no mesmo item;
- itens `pending` não podem possuir classificação;
- itens `won` ou `lost` precisam possuir pelo menos uma classificação;
- cada item possui sua própria lista de colocações;
- a remoção da classificação do item também remove suas colocações.

A estrutura anterior baseada apenas em `classification_position` foi substituída pela tabela de rankings.

### Totais calculados

O retorno contém:

```text
totals.original
totals.minimum
totals.won
```

Também é retornada uma lista `won_items` somente com os itens classificados como vencedores.

### Finalização e reabertura

O acompanhamento pode ser:

- finalizado;
- reaberto;
- consultado mesmo quando finalizado.

Ao finalizar, o backend registra `finished_at`.

### Impressão e exportação

Foi implementado um payload específico para impressão, contendo:

- dados da proposta;
- empresa;
- licitação;
- itens;
- classificações;
- preços mínimos;
- totais;
- relatório de itens ganhos;
- informações documentais.

Também foi implementada exportação CSV com:

- identificação do item;
- descrição;
- quantidade;
- unidade;
- marca;
- preço original;
- preço mínimo;
- resultado;
- primeiro, segundo e terceiro colocados;
- empresa, marca e preço de cada posição.

### Endpoints de acompanhamento

```text
GET  /api/proposal/{proposal_id}/tracking
PUT  /api/proposal/{proposal_id}/tracking

POST /api/proposal/{proposal_id}/tracking/apply-discount
POST /api/proposal/{proposal_id}/tracking/finish
POST /api/proposal/{proposal_id}/tracking/reopen

GET  /api/proposal/{proposal_id}/tracking/print
GET  /api/proposal/{proposal_id}/tracking/export
```

## Catálogo de propostas

Foi implementada a estrutura de backend para a funcionalidade **Criar catálogo (Beta)**.

Cada proposta pode possuir apenas um catálogo.

Na primeira consulta, o backend:

- cria o catálogo automaticamente;
- copia os dados da empresa;
- copia os dados do órgão e da licitação;
- copia os itens atuais da proposta;
- mantém um snapshot independente da proposta original;
- evita duplicação em consultas posteriores.

Alterações futuras na proposta, empresa ou licitação não modificam silenciosamente o catálogo já criado.

### Dados do catálogo

O catálogo armazena:

```text
title
subtitle
general_notes
organ_name
organ_state
purchase_number
process_number
receipt_date
opening_date
company_snapshot
last_updated_by
generated_at
```

O título inicial é `Catálogo de Produtos`.

### Itens do catálogo

Cada item possui:

```text
proposal_item_id
title
specification
quantity
unit
brand
position
image_original_name
image_mime
image_url
```

O catálogo suporta:

- itens originados da proposta;
- itens adicionados manualmente;
- edição dos dados copiados;
- ordenação manual;
- inclusão de novos itens;
- remoção de itens;
- preservação das imagens dos itens mantidos;
- exclusão da imagem quando o item é removido.

O vínculo `proposal_item_id` de um item existente é imutável. Itens manuais possuem `proposal_item_id` nulo.

### Salvamento transacional

O catálogo inteiro é salvo por um único `PUT`.

Quando `items` não é enviado:

- os itens atuais permanecem inalterados.

Quando `items` é enviado:

- representa a lista final completa;
- itens existentes precisam enviar `id`;
- itens omitidos são removidos;
- itens sem `id` são criados;
- posições não podem se repetir;
- as posições são normalizadas para `1..N`;
- trocas de posição são realizadas sem violar a constraint única;
- toda a alteração ocorre dentro de uma transação.

O retorno contém os IDs definitivos dos itens novos.

### Imagens

Cada item pode possuir uma imagem independente.

Formatos aceitos:

```text
JPG
JPEG
PNG
WEBP
```

Tamanho máximo: 5 MB.

As imagens são armazenadas em:

```text
proposal-catalogs/{catalog_id}
```

A API não expõe o caminho interno do arquivo. O frontend deve utilizar `image_url`.

Ao substituir uma imagem:

- a nova imagem é armazenada;
- o registro é atualizado;
- a imagem anterior é removida.

Ao remover uma imagem:

- os campos do item são limpos;
- o arquivo físico também é removido.

### Geração do catálogo

A ação de gerar catálogo registra `generated_at`.

Qualquer alteração posterior no catálogo ou nas imagens limpa esse campo, indicando que existe conteúdo ainda não gerado novamente.

O backend retorna os dados necessários para a visualização, mas não gera HTML ou PDF.

A montagem do documento, edição temporária, impressão e PDF ficam sob responsabilidade do frontend e do navegador.

### Visualização

Existe um endpoint autenticado de visualização por identificador próprio do catálogo. Não foi implementado compartilhamento público.

### Endpoints do catálogo

```text
GET    /api/proposal/{proposal_id}/catalog
PUT    /api/proposal/{proposal_id}/catalog

POST   /api/proposal/{proposal_id}/catalog/generate

POST   /api/proposal/{proposal_id}/catalog/items/{item_id}/image
DELETE /api/proposal/{proposal_id}/catalog/items/{item_id}/image

GET    /api/proposal-catalog/{catalog_id}/view
```

## Segurança e autorização

As funcionalidades utilizam a autenticação JWT e o middleware de usuário ativo já existentes.

O backend valida:

- se a proposta pertence ao usuário autenticado;
- se o catálogo pertence ao usuário;
- se o item pertence ao catálogo informado;
- se o item de origem pertence à proposta;
- se rankings pertencem ao item correto;
- se IDs de outros usuários ou propostas foram enviados.

Recursos inexistentes ou fora do escopo do usuário retornam `404`.

Erros de validação retornam `400`.

Acompanhamentos finalizados retornam `409` quando houver tentativa de alteração.

## Models e relacionamentos

Foram adicionados:

```text
ProposalTracking
ProposalTrackingItem
ProposalTrackingItemRanking
ProposalCatalog
ProposalCatalogItem
```

Também foram adicionados relacionamentos em:

```text
Proposal
ProposalItem
Company
User
```

## Migrations

Este PR adiciona:

```text
2026_07_15_000001_add_calendar_date_to_calendar_tenders_table.php
2026_07_15_000002_create_proposal_trackings_tables.php
2026_07_15_000003_replace_tracking_classification_position_with_rankings.php
2026_07_15_000004_create_proposal_catalogs_tables.php
```

A migration dos rankings utiliza nomes explícitos e reduzidos para as constraints, evitando o limite de 64 caracteres do MySQL.

Ela também trata a recuperação de uma execução anterior que possa ter deixado a tabela de rankings criada parcialmente após uma falha de constraint.

## Documentação

Foram criados:

```text
docs/acompanhamento-de-propostas.md
docs/catalogo-de-propostas.md
```

Os documentos registram:

- análise das funcionalidades do sistema utilizado como referência;
- layout observado;
- campos e comportamentos;
- regras de negócio;
- cálculos;
- contratos da API;
- exemplos de payload;
- responsabilidades do backend;
- responsabilidades do frontend;
- pontos observados e inferências;
- prompts de implementação para o agente do frontend.

## Testes

Foram adicionados testes para:

- filtro por múltiplos domínios;
- filtro por string separada por vírgulas;
- inicialização do acompanhamento;
- aplicação não cumulativa de desconto;
- cálculo de valores mínimos;
- resultados vencedor, perdido e pendente;
- classificação dos três primeiros colocados;
- rejeição de posições duplicadas;
- rejeição de itens de outra proposta;
- finalização e reabertura;
- bloqueio de edição após finalização;
- relatório de itens ganhos;
- payload de impressão;
- exportação CSV;
- criação idempotente do catálogo;
- snapshot da empresa e da proposta;
- inclusão, ordenação e remoção de itens;
- itens adicionados manualmente;
- validação de pertencimento;
- isolamento entre usuários;
- upload, substituição e remoção de imagens;
- geração e visualização do catálogo.

Resultado da suíte completa:

```text
26 testes aprovados
129 asserções
```

Comando executado:

```bash
php artisan test
```

A migration também foi aplicada com sucesso no MySQL local:

```bash
php artisan migrate --force
```

## Instruções para implantação

Executar:

```bash
php artisan migrate
```

Para que `image_url` funcione corretamente, o ambiente deve possuir o link público do storage:

```bash
php artisan storage:link
```

O frontend deve observar que:

- a lista enviada em `items` no `PUT` do catálogo é a lista final completa;
- itens omitidos são excluídos;
- itens novos precisam ser salvos antes do upload da imagem;
- o upload utiliza `multipart/form-data`;
- `image_url` deve ser usado em vez de construir o caminho manualmente;
- a impressão e a edição temporária da visualização são responsabilidades do frontend.

## Checklist

- [x] Data personalizada no calendário
- [x] Alteração de data e status
- [x] Retorno preparado para kanban
- [x] Filtro por domínios de origem
- [x] Acompanhamento de propostas
- [x] Preços mínimos e descontos
- [x] Resultados vencedor/perdido
- [x] Primeiro, segundo e terceiro colocados
- [x] Relatório de itens ganhos
- [x] Impressão e exportação CSV
- [x] Catálogo de propostas
- [x] Ordenação e itens manuais
- [x] Upload e remoção de imagens
- [x] Visualização autenticada
- [x] Migrations aplicadas
- [x] Documentação criada
- [x] Testes automatizados aprovados